### PR TITLE
Update branch parameters and add parameter for argocd app

### DIFF
--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -160,7 +163,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -178,7 +181,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:eclipse-$(params.toBranch) 
       - --health

--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -106,7 +106,7 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.toBranch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace

--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -124,7 +127,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -142,7 +145,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:extensions-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -106,7 +106,7 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.toBranch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -124,7 +127,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -142,7 +145,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos 
+      - $(params.appname) 
       - --resource
       - apps:Deployment:framework-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -8,7 +8,10 @@ metadata:
   namespace: galasa-build
 spec:
   params:
-  - name: branch
+  - name: fromBranch
+    type: string
+    default: main
+  - name: toBranch
     type: string
     default: main
   - name: refspec
@@ -41,7 +44,7 @@ spec:
     - name: url
       value: https://github.com/galasa-dev/gradle
     - name: revision
-      value: $(params.branch)
+      value: $(params.toBranch)
     - name: refspec
       value: $(params.refspec)
     - name: depth
@@ -98,12 +101,12 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/gradle/gradle-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-gradle:$(params.branch)
+      value: harbor.galasa.dev/galasadev/galasa-gradle:$(params.toBranch)
     - name: noPush
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.branch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace
@@ -126,7 +129,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - gradle-$(params.branch)
+      - gradle-$(params.toBranch)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -141,7 +144,7 @@ spec:
       - wait
       - main-maven-repos
       - --resource
-      - apps:Deployment:gradle-$(params.branch)
+      - apps:Deployment:gradle-$(params.toBranch)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -124,7 +127,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -142,7 +145,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:gradle-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/isolated/build-branch.yaml
+++ b/pipelines/pipelines/isolated/build-branch.yaml
@@ -19,7 +19,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
-   
+  - name: appname
+    type: string
+    default: main-maven-repos
   tasks:
   - name: clone-automation
     taskRef: 
@@ -593,7 +595,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -611,7 +613,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:isolated-$(params.toBranch) 
       - --health
@@ -1071,7 +1073,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -1089,7 +1091,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:mvp-$(params.toBranch) 
       - --health

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -124,7 +127,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -142,7 +145,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:managers-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -106,7 +106,7 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.toBranch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -136,7 +139,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -154,7 +157,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:maven-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -8,7 +8,10 @@ metadata:
   namespace: galasa-build
 spec:
   params:
-  - name: branch
+  - name: fromBranch
+    type: string
+    default: main
+  - name: toBranch
     type: string
     default: main
   - name: refspec
@@ -41,7 +44,7 @@ spec:
     - name: url
       value: https://github.com/galasa-dev/maven
     - name: revision
-      value: $(params.branch)
+      value: $(params.toBranch)
     - name: refspec
       value: $(params.refspec)
     - name: depth
@@ -110,12 +113,12 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/maven/maven-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-maven:$(params.branch)
+      value: harbor.galasa.dev/galasadev/galasa-maven:$(params.toBranch)
     - name: noPush
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.branch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace
@@ -138,7 +141,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - maven-$(params.branch)
+      - maven-$(params.toBranch)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -153,7 +156,7 @@ spec:
       - wait
       - main-maven-repos
       - --resource
-      - apps:Deployment:maven-$(params.branch)
+      - apps:Deployment:maven-$(params.toBranch)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -295,7 +298,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -313,7 +316,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:obr-$(params.toBranch)
       - --health
@@ -423,7 +426,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -441,7 +444,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:javadoc-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -277,7 +277,7 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=tag=$(params.toBranch)"
+        - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
      - name: git-workspace

--- a/pipelines/pipelines/simplatform/build-branch.yaml
+++ b/pipelines/pipelines/simplatform/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -186,7 +189,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart 
       - --kind 
       - Deployment
@@ -204,7 +207,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:simplatform-$(params.toBranch)
       - --health

--- a/pipelines/pipelines/wrapping/build-branch.yaml
+++ b/pipelines/pipelines/wrapping/build-branch.yaml
@@ -14,6 +14,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: appname
+    type: string
+    default: main-maven-repos
   workspaces:
   - name: git-workspace
   tasks:
@@ -133,7 +136,7 @@ spec:
       - app 
       - actions 
       - run 
-      - main-maven-repos
+      - $(params.appname)
       - restart
       - --kind 
       - Deployment
@@ -151,7 +154,7 @@ spec:
       value: 
       - app 
       - wait
-      - main-maven-repos
+      - $(params.appname)
       - --resource
       - apps:Deployment:wrapping-$(params.branch)
       - --health


### PR DESCRIPTION
Update branch parameters to fix branch-level build failures and add a parameter to be able to specify the argocd app that is being deployed to (defaults to main-maven-repos).