### PR TITLE
Remove port names from deployments

### DIFF
--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/extensions/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/extensions/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.extensions.branch }}/maven-repo/extensions
           ports:
             - containerPort: 80
-              name: extensions-{{ .Values.extensions.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/framework/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/framework/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.framework.branch }}/maven-repo/framework
           ports:
             - containerPort: 80
-              name: framework-{{ .Values.framework.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/gradle/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/gradle/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.gradle.branch }}/maven-repo/gradle
           ports:
             - containerPort: 80
-              name: gradle-{{ .Values.gradle.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/javadoc/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/javadoc/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.javadoc.branch }}/maven-repo/javadoc
           ports:
             - containerPort: 80
-              name: javadoc-{{ .Values.javadoc.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/managers/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/managers/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.managers.branch }}/maven-repo/managers
           ports:
             - containerPort: 80
-              name: managers-{{ .Values.managers.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/maven/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/maven/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.maven.branch }}/maven-repo/maven
           ports:
             - containerPort: 80
-              name: maven-{{ .Values.maven.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/obr/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/obr/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.obr.branch }}/maven-repo/obr
           ports:
             - containerPort: 80
-              name: obr-{{ .Values.obr.branch }}
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/wrapping/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/wrapping/deployment.yaml
@@ -28,5 +28,4 @@ spec:
             value: {{ .Values.wrapping.branch }}/maven-repo/wrapping
           ports:
             - containerPort: 80
-              name: wrapping-{{ .Values.wrapping.branch }}
 {{ end }}


### PR DESCRIPTION
To fix a port name character limit error in Argo CD 