### PR TITLE
Add imageTag parameter and update branch params for eclipse and isolated

### DIFF
--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -119,7 +122,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/eclipse/eclipse-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-eclipse:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-eclipse:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -144,7 +147,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/eclipse/eclipse-p2-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-eclipse-p2:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-eclipse-p2:$(params.imageTag)
     - name: noPush
       value: ""
     workspaces:
@@ -168,7 +171,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - eclipse-$(params.toBranch) 
+      - eclipse-$(params.imageTag) 
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -183,7 +186,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:eclipse-$(params.toBranch) 
+      - apps:Deployment:eclipse-$(params.imageTag) 
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -8,7 +8,10 @@ metadata:
   namespace: galasa-build
 spec:
   params:
-  - name: fromBranch
+  - name: fromObrBranch
+    type: string
+    default: main
+  - name: fromSimplatformBranch
     type: string
     default: main
   - name: toBranch
@@ -101,8 +104,8 @@ spec:
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/eclipse/repo"
         - "-Dgalasa.source.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.eclipse.repo=http://download.eclipse.org/releases/photon"
-        - "-Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr"
-        - "-Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform"
+        - "-Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr"
+        - "-Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform"
     - name: command
       value: deploy
     workspaces:

--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -104,7 +107,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/extensions/extensions-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-extensions:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-extensions:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -132,7 +135,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - extensions-$(params.toBranch)
+      - extensions-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -147,7 +150,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:extensions-$(params.toBranch)
+      - apps:Deployment:extensions-$(params.imageTag)
       - --health
   
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -104,7 +107,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/framework/framework-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-framework:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-framework:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -132,7 +135,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - framework-$(params.toBranch)
+      - framework-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -147,7 +150,7 @@ spec:
       - wait
       - $(params.appname) 
       - --resource
-      - apps:Deployment:framework-$(params.toBranch)
+      - apps:Deployment:framework-$(params.imageTag)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -104,7 +107,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/gradle/gradle-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-gradle:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-gradle:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -132,7 +135,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - gradle-$(params.toBranch)
+      - gradle-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -147,7 +150,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:gradle-$(params.toBranch)
+      - apps:Deployment:gradle-$(params.imageTag)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/isolated/build-branch.yaml
+++ b/pipelines/pipelines/isolated/build-branch.yaml
@@ -10,7 +10,16 @@ spec:
   workspaces:
   - name: git-workspace
   params:
-  - name: fromBranch
+  - name: fromObrBranch
+    type: string
+    default: main
+  - name: fromSimplatformBranch
+    type: string
+    default: main
+  - name: fromJavadocBranch
+    type: string
+    default: main
+  - name: fromEclipseBranch
     type: string
     default: main
   - name: toBranch
@@ -195,12 +204,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -229,12 +238,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -263,12 +272,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -296,12 +305,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -330,12 +339,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -363,12 +372,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -396,12 +405,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -429,12 +438,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -541,12 +550,12 @@ spec:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
         - -Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/isolated/full/repo
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -673,12 +682,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -707,12 +716,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -741,12 +750,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -774,12 +783,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -808,12 +817,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -841,12 +850,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -874,12 +883,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -907,12 +916,12 @@ spec:
       value:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B
@@ -1019,12 +1028,12 @@ spec:
         - -Dgpg.skip=true
         - -Dgalasa.target.repo=file:target/isolated/maven
         - -Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/isolated/mvp/repo
-        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/obr
-        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/simplatform
-        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/javadoc
+        - -Dgalasa.runtime.repo=https://development.galasa.dev/$(params.fromObrBranch)/maven-repo/obr
+        - -Dgalasa.simplatform.repo=https://development.galasa.dev/$(params.fromSimplatformBranch)/maven-repo/simplatform
+        - -Dgalasa.javadoc.repo=https://development.galasa.dev/$(params.fromJavadocBranch)/maven-repo/javadoc
         - -Dgalasa.docs.repo=https://nexus.galasa.dev/repository/docs/
         - -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/
-        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromBranch)/maven-repo/eclipse
+        - -Dgalasa.eclipse.repo=https://development.galasa.dev/$(params.fromEclipseBranch)/maven-repo/eclipse
         # - --settings
         # - /workspace/git/$(context.pipelineRun.name)/isolated/settings.xml
         - -B

--- a/pipelines/pipelines/isolated/build-branch.yaml
+++ b/pipelines/pipelines/isolated/build-branch.yaml
@@ -19,6 +19,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -491,7 +494,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
-      value: icr.io/galasadev/galasa-isolated:$(params.toBranch)
+      value: icr.io/galasadev/galasa-isolated:$(params.imageTag)
     - name: noPush
       value: ""
     workspaces:
@@ -511,7 +514,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
-      value: icr.io/galasadev/galasa-distibution:$(params.toBranch)
+      value: icr.io/galasadev/galasa-distibution:$(params.imageTag)
     - name: noPush
       value: "--no-push"
     - name: buildArgs
@@ -571,7 +574,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfileZip
     - name: imageName
-      value: icr.io/galasadev/galasa-isolated-zip:$(params.toBranch)
+      value: icr.io/galasadev/galasa-isolated-zip:$(params.imageTag)
     - name: noPush
       value: ""  
     - name: buildArgs
@@ -600,7 +603,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - isolated-$(params.toBranch) 
+      - isolated-$(params.imageTag) 
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -615,7 +618,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:isolated-$(params.toBranch) 
+      - apps:Deployment:isolated-$(params.imageTag) 
       - --health
 
 
@@ -969,7 +972,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
-      value: icr.io/galasadev/galasa-mvp:$(params.toBranch)
+      value: icr.io/galasadev/galasa-mvp:$(params.imageTag)
     - name: noPush
       value: ""
     workspaces:
@@ -989,7 +992,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
-      value: icr.io/galasadev/galasa-distribution:$(params.toBranch)
+      value: icr.io/galasadev/galasa-distribution:$(params.imageTag)
     - name: noPush
       value: "--no-push"
     - name: buildArgs
@@ -1049,7 +1052,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfileZip
     - name: imageName
-      value: icr.io/galasadev/galasa-mvp-zip:$(params.toBranch)
+      value: icr.io/galasadev/galasa-mvp-zip:$(params.imageTag)
     - name: noPush
       value: ""  
     - name: buildArgs
@@ -1078,7 +1081,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - mvp-$(params.toBranch) 
+      - mvp-$(params.imageTag) 
   - name: wait-deployment-mvp
     taskRef:
       name: argocd-cli
@@ -1093,7 +1096,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:mvp-$(params.toBranch) 
+      - apps:Deployment:mvp-$(params.imageTag) 
       - --health
                 
 

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -104,7 +107,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/managers/managers-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-managers:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-managers:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -132,7 +135,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - managers-$(params.toBranch)
+      - managers-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -147,7 +150,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:managers-$(params.toBranch)
+      - apps:Deployment:managers-$(params.imageTag)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -116,7 +119,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/maven/maven-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-maven:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-maven:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -144,7 +147,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - maven-$(params.toBranch)
+      - maven-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -159,7 +162,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:maven-$(params.toBranch)
+      - apps:Deployment:maven-$(params.imageTag)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -275,7 +278,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/obr/obr-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-obr:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-obr:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -303,7 +306,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - obr-$(params.toBranch)
+      - obr-$(params.imageTag)
   - name: wait-obr-deployment
     taskRef:
       name: argocd-cli
@@ -318,7 +321,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:obr-$(params.toBranch)
+      - apps:Deployment:obr-$(params.imageTag)
       - --health
 
 ### JAVADOC
@@ -380,7 +383,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-javadoc-site:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-javadoc-site:$(params.imageTag)
     - name: context
       value: $(context.pipelineRun.name)/obr/javadocs
     - name: noPush
@@ -399,7 +402,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-javadoc-maven-repo:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-javadoc-maven-repo:$(params.imageTag)
     - name: context
       value: $(context.pipelineRun.name)/obr/javadocs/docker
     - name: noPush
@@ -431,7 +434,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - javadoc-$(params.toBranch)
+      - javadoc-$(params.imageTag)
   - name: wait-javadoc-maven-repo
     taskRef:
       name: argocd-cli
@@ -446,7 +449,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:javadoc-$(params.toBranch)
+      - apps:Deployment:javadoc-$(params.imageTag)
       - --health
   - name: recycle-javadoc-site
     taskRef:

--- a/pipelines/pipelines/simplatform/build-branch.yaml
+++ b/pipelines/pipelines/simplatform/build-branch.yaml
@@ -17,6 +17,9 @@ spec:
   - name: refspec
     type: string
     default: refs/heads/main:refs/heads/main
+  - name: imageTag
+    type: string
+    default: main
   - name: appname
     type: string
     default: main-maven-repos
@@ -141,7 +144,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/simplatform/simplatform-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-simplatform:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-simplatform:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
@@ -166,7 +169,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/simplatform/simplatform-amd64-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasa-simplatform-amd64:$(params.toBranch)
+      value: harbor.galasa.dev/galasadev/galasa-simplatform-amd64:$(params.imageTag)
     - name: noPush
       value: ""
     # - name: buildArgs
@@ -194,7 +197,7 @@ spec:
       - --kind 
       - Deployment
       - --resource-name
-      - simplatform-$(params.toBranch)
+      - simplatform-$(params.imageTag)
   - name: wait-deployment
     taskRef:
       name: argocd-cli
@@ -209,7 +212,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:simplatform-$(params.toBranch)
+      - apps:Deployment:simplatform-$(params.imageTag)
       - --health
 
   # Commenting out for now, until we decide whether to stay with VolumeClaimTemplate per PRun or go back to PVC


### PR DESCRIPTION
- Add an `imageTag` parameter to avoid creating images tagged "main" when running builds with downstream branch changes, adding flexibility when tagging images
    - For example: this allows us to build obr:branch when cloning obr's main branch, rather than only tagging an image based on the branch that was cloned (e.g. obr:main when cloning the main branch)
- Adds separate branch parameters for eclipse and isolated builds (e.g. `fromObrBranch`, `fromSimplatformBranch`, etc.)