### PR TITLE
Add member role for code committers

### DIFF
--- a/infrastructure/ibmcloud-galasadev-cluster/argocd/argocd-rbac-cm.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/argocd/argocd-rbac-cm.yaml
@@ -1,3 +1,6 @@
+#
+# Copyright contributors to the Galasa project
+#
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,5 +12,23 @@ metadata:
 data:
   policy.default: role:readonly
   policy.csv: |
+    p, role:member, applications, create, default/main-maven-repos, deny
+    p, role:member, applications, create, default/javadoc-site, deny
+    p, role:member, applications, create, default/galasa-development-namespace, deny
+    p, role:member, applications, delete, default/main-maven-repos, deny
+    p, role:member, applications, delete, default/javadoc-site, deny
+    p, role:member, applications, delete, default/galasa-development-namespace, deny
+    p, role:member, applications, update, default/main-maven-repos, deny
+    p, role:member, applications, update, default/javadoc-site, deny
+    p, role:member, applications, update, default/galasa-development-namespace, deny
+    p, role:member, applications, sync, default/main-maven-repos, deny
+    p, role:member, applications, sync, default/javadoc-site, deny
+    p, role:member, applications, sync, default/galasa-development-namespace, deny
+    p, role:member, applications, create, default/*, allow
+    p, role:member, applications, delete, default/*, allow
+    p, role:member, applications, update, default/*, allow
+    p, role:member, applications, sync, default/*, allow
+    
     g, galasa, role:admin
     g, galasa-dev:code-admin, role:admin
+    g, galasa-dev:code-committers, role:member


### PR DESCRIPTION
- Code committers can now create, update, delete, and sync new ArgoCD apps.
- Existing apps (main-maven-repos, javadoc-site, and galasa-development-namespace) will continue to be managed by admins only.