### PR TITLE
javadoc builds to use java later than v11. v18 introduced

### DIFF
--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -341,7 +341,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:obr-$(params.imageTag)
+      - apps:Deployment:obr-$(paarams.imageTag)
       - --health
 
 ### JAVADOC
@@ -374,7 +374,7 @@ spec:
        workspace: git-workspace
   - name: maven-build-javadoc
     taskRef: 
-      name: maven-build
+      name: maven-build-java18
     runAfter: 
     - generate-javadoc
     params:

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -341,7 +341,7 @@ spec:
       - wait
       - $(params.appname)
       - --resource
-      - apps:Deployment:obr-$(paarams.imageTag)
+      - apps:Deployment:obr-$(params.imageTag)
       - --health
 
 ### JAVADOC

--- a/pipelines/pipelines/obr/build-pr.yaml
+++ b/pipelines/pipelines/obr/build-pr.yaml
@@ -206,7 +206,7 @@ spec:
        workspace: git-workspace 
   - name: maven-build-bom
     taskRef:
-      name: maven-build
+      name: maven-build-java18
     runAfter: 
       - list-bom
     params:

--- a/pipelines/tasks/maven-build-java18.yaml
+++ b/pipelines/tasks/maven-build-java18.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright contributors to the Galasa project 
+#
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: maven-build-java18
+  namespace: galasa-build
+spec:
+  workspaces:
+  - name: git-workspace
+    mountPath: /workspace/git
+  params:
+  - name: context
+    type: string 
+  - name: settingsLocation
+    type: string
+  - name: buildArgs
+    type: array    
+  - name: command
+    type: array  
+  steps:
+  - name: maven-build
+    workingDir: /workspace/git/$(params.context)
+    image: docker.io/library/maven:3.8.7-openjdk-18 
+    imagePullPolicy: Always
+    command:
+      - mvn
+    args:
+      - $(params.buildArgs[*])
+      - --settings
+      - $(params.settingsLocation)
+      - --batch-mode
+      - --errors
+      - --fail-at-end
+      - $(params.command[*]) 
+
+  


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
