### PR TITLE
techcobweb javadoc uses recent jdk

### DIFF
--- a/pipelines/pipelines/obr/build-pr.yaml
+++ b/pipelines/pipelines/obr/build-pr.yaml
@@ -206,7 +206,7 @@ spec:
        workspace: git-workspace 
   - name: maven-build-bom
     taskRef:
-      name: maven-build-java18
+      name: maven-build
     runAfter: 
       - list-bom
     params:
@@ -344,7 +344,7 @@ spec:
        workspace: git-workspace
   - name: maven-build-javadoc
     taskRef: 
-      name: maven-build
+      name: maven-build-java18
     runAfter: 
     - generate-javadoc
     params:


### PR DESCRIPTION
- javadoc builds to use java later than v11. v18 introduced
- javadoc builds to use java later than v11. v18 introduced
- javadoc build should use java 18
