### PR TITLE
Github webhook received can exclude some repositories from processing

### DIFF
--- a/build-images/github-webhook-receiver/cmd/github-webhook-receiver/main_test.go
+++ b/build-images/github-webhook-receiver/cmd/github-webhook-receiver/main_test.go
@@ -559,3 +559,27 @@ func TestCanUnmarshallPullRequestOpen(t *testing.T) {
 		assert.Equal(t, "opened", pPayload.Action, "Parsing payload failed to pick up the action.")
 	}
 }
+
+func TestIsExcludedWhenThereAreNoExclusionsShouldNotExclude(t *testing.T) {
+	excludedRepositories := make([]string, 0)
+	repoName := "notToBeExcludedRepo"
+
+	result := isExcluded(repoName, excludedRepositories)
+	assert.False(t, result, "Should not be excluded, but it was.")
+}
+
+func TestIsExcludedWhenThereAreTwoDifferingExclusionsShouldNotExclude(t *testing.T) {
+	excludedRepositories := []string {"notMatching1","notMatching2"}
+	repoName := "notToBeExcludedRepo"
+
+	result := isExcluded(repoName, excludedRepositories)
+	assert.False(t, result, "Should not be excluded, but it was.")
+}
+
+func TestIsExcludedShouldExcludeIfThereIsAMatch(t *testing.T) {
+	excludedRepositories := []string {"notMatching1","matching2"}
+	repoName := "matching2"
+
+	result := isExcluded(repoName, excludedRepositories)
+	assert.True(t, result, "Should be excluded, but it was not.")
+}

--- a/build-images/github-webhook-receiver/pkg/cmd/root.go
+++ b/build-images/github-webhook-receiver/pkg/cmd/root.go
@@ -21,8 +21,9 @@ var (
 		Run:     gatherInputs,
 	}
 
-	githubToken string
-	port        int32
+	githubToken   string
+	port          int32
+	excludedRepos []string
 )
 
 func init() {
@@ -31,6 +32,10 @@ func init() {
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	rootCmd.PersistentFlags().StringVarP(&githubToken, "githubtoken", "g",
 		defaultGitHubToken, "The github token. Defaults to value of the GITHUBTOKEN environment variable.")
+
+	excludeUsage := "Name of a repository which will be silently excluded from processing." +
+		"Multiple instance of this flag can be used to specify many repositories which are excluded."
+	rootCmd.Flags().StringSliceVar(&excludedRepos, "exclude", make([]string, 0), excludeUsage)
 }
 
 func GetInputs() (*env.Inputs, error) {
@@ -48,6 +53,7 @@ func GetInputs() (*env.Inputs, error) {
 		// Populate the structure
 		inputs.Port = port
 		inputs.GithubToken = githubToken
+		inputs.ExcludedRepositories = excludedRepos
 
 		// Do any validation we can.
 		err = env.ValidateGitHubToken(inputs.GithubToken)

--- a/build-images/github-webhook-receiver/pkg/env/env.go
+++ b/build-images/github-webhook-receiver/pkg/env/env.go
@@ -9,13 +9,17 @@ import (
 )
 
 type Inputs struct {
-	GithubToken string
-	Port        int32
+	GithubToken          string
+	Port                 int32
+	ExcludedRepositories []string
 }
 
 func (inputs *Inputs) Log() {
 	log.Printf("Github token length: %d\n", len(inputs.GithubToken))
 	log.Printf("Port to listen on: %d\n", inputs.Port)
+	for _, repoName := range inputs.ExcludedRepositories {
+		log.Printf("Excluding repository: %s", repoName)
+	}
 }
 
 func ValidateGitHubToken(token string) error {
@@ -25,5 +29,3 @@ func ValidateGitHubToken(token string) error {
 	}
 	return err
 }
-
-

--- a/build-images/github-webhook-receiver/pkg/types/pullrequest.go
+++ b/build-images/github-webhook-receiver/pkg/types/pullrequest.go
@@ -9,9 +9,15 @@ type Payload struct {
 }
 
 type PullRequest struct {
-	Url         string `json:"url"`
-	IssueUrl    string `json:"issue_url"`
-	State       string `json:"state"` // Expected to be "open"
-	Title       string `json:"title"` // So we can log the pull request title.
-	StatusesUrl string `json:"statuses_url"`
+	Url         string     `json:"url"`
+	IssueUrl    string     `json:"issue_url"`
+	State       string     `json:"state"` // Expected to be "open"
+	Title       string     `json:"title"` // So we can log the pull request title.
+	StatusesUrl string     `json:"statuses_url"`
+	Repository  Repository `json:"repository"`
+}
+
+type Repository struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
 }

--- a/pipelines/pipelines/automation/build-branch.yaml
+++ b/pipelines/pipelines/automation/build-branch.yaml
@@ -243,6 +243,10 @@ spec:
 #  Kick the argocd application to refresh, causing a re-deployment
 # 
 # 
+#  Note: The --exclude flags causes some repositories not to be told
+#  that a Tekton build is starting. All other PRs in repos in the organisation
+#  will receive notification that the Tekton build is starting shortly...
+#
   - name: recycle-webhook-receiver-deployment
     taskRef:
       name: argocd-cli
@@ -262,6 +266,10 @@ spec:
       - Deployment
       - --resource-name
       - github-webhook-receiver
+      - --exclude
+      - galasa.dev
+      - --exclude
+      - helm
 # 
 # 
 # Wait for the redeployment to complete.


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Normally:
a) A webhook from the Github organisation gets sent to the webhook-received.
b) The repository in github for which there is a PR/Build gets told that a Tekton build will start soon.
c) The webhook received returns OK to that HTTP request always.
d) The github monitor will poll github looking for webhooks which were recently delivered, and fire the PR events to the Tekton listener.
e) The listener launches a pipeline off to do the build.
f) The pipeline tells the github pull request that the tekton build has complete with status.

Step b causes problems with blocking pull requests in cases where there is no tekton build for the repository set up yet.

With this PR, you can now set a list of repositories such that steps b is not performed if a PR comes from them.

Several repositories can be excluded from processing at once.

