### PR TITLE
cli build uses gradle

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -72,8 +72,6 @@ spec:
   - name: clone-cli
     taskRef: 
       name: git-clone
-    runAfter:
-    - git-verify  
     params:
     - name: url
       value: https://github.com/galasa-dev/cli


### PR DESCRIPTION
- Github webhook received can exclude some repositories from processing
- automation to call gradle prior to CLI build
- correction to cli pipeline
