### PR TITLE
cli build uses gradle

### DIFF
--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -137,7 +137,7 @@ spec:
   # talk to the API server.
   - name: generate-api
     taskRef: 
-      name: generate-command
+      name: general-command
     runAfter:
     - gather-dependencies
     params:

--- a/pipelines/pipelines/framework/build-pr.yaml
+++ b/pipelines/pipelines/framework/build-pr.yaml
@@ -90,6 +90,7 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
+
   - name: gradle-build-framework
     taskRef:
       name: gradle-build


### PR DESCRIPTION
- Github webhook received can exclude some repositories from processing
- automation to call gradle prior to CLI build
- correction to cli pipeline
- fix the context when the gradle action fires
- general-command typo
