### PR TITLE
cli build uses gradle

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -95,8 +95,9 @@ spec:
     runAfter: 
     - clone-cli
     params:
+    # The context indicates which folder the build.gradle is in.
     - name: context
-      value: $(context.pipelineRun.name)/framework/galasa-parent
+      value: $(context.pipelineRun.name)/cli
     - name: buildArgs
       value:
         - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -118,8 +118,9 @@ spec:
     runAfter: 
     - clone-cli
     params:
+    # The context indicates which folder the build.gradle is in.
     - name: context
-      value: $(context.pipelineRun.name)/cli/galasa-parent
+      value: $(context.pipelineRun.name)/cli
     - name: buildArgs
       value:
         - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"


### PR DESCRIPTION
- Github webhook received can exclude some repositories from processing
- automation to call gradle prior to CLI build
- correction to cli pipeline
- fix the context when the gradle action fires
- general-command typo
- context of gradle build needs to be in the correct folder
