### PR TITLE
cli build uses gradle

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -106,6 +106,7 @@ spec:
     - name: command
       value: 
         - installJarsIntoTemplates
+        - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -129,6 +129,7 @@ spec:
     - name: command
       value: 
         - installJarsIntoTemplates
+        - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace


### PR DESCRIPTION
- Github webhook received can exclude some repositories from processing
- automation to call gradle prior to CLI build
- correction to cli pipeline
- fix the context when the gradle action fires
- general-command typo
- context of gradle build needs to be in the correct folder
- try to get more logging out of CLI gradle task
