### PR TITLE
Update release documentation to delete all 'release' images manually - Issue 1112

### DIFF
--- a/releasePipeline/README.md
+++ b/releasePipeline/README.md
@@ -98,10 +98,10 @@ All the tests must pass before moving on.
 
 ### Clean up
 
-1. Run `kubectl -n galasa-build create -f 90-delete-all-branches.yaml` - Delete the release branch in ALL repos.
-<!-- Temporary step until we can automate deleting the 'release' images: -->
-1. Go to [Harbor](harbor.galasa.dev) and delete all images tagged 'release' (tick box next to image tagged 'release' and select Actions then Delete)
-1. Go to [IBM Cloud Container Registry](https://cloud.ibm.com/registry/images) and delete all images tagged 'release' (click three dots next to 'release' image and select Delete image)
+<!-- 1. Run `kubectl -n galasa-build create -f 90-delete-all-branches.yaml` - Delete the release branch in ALL repos. -->
+<!-- Temporary steps until we can automate deleting the 'release' images: -->
+1. Go through the images in [Harbor](harbor.galasa.dev) and delete all images tagged 'release' that were built as part of this release (tick box next to image tagged 'release' and select Actions then Delete)
+1. Go through the images in [IBM Cloud Container Registry](https://cloud.ibm.com/registry/images) and delete all images tagged 'release' that were built as part of this release (click three dots next to 'release' image and select Delete image)
 <!-- End of temporary steps-->
 1. 92-delete-argocd-apps.sh - Remove the ArgoCD applications, and therefore the Kubernetes resources.
 


### PR DESCRIPTION
I have updated the release documentation to instruct whoever is releasing Galasa to delete the 'release' images manually for now, until we are able to automate this step using the branch-delete-all Pipeline (Items 1391 and 1392 will do this. Once complete, I'll update the documentation again to reflect this). 

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>