### PR TITLE
CodeCoverage path fix to deploy report - Issue 1295

### DIFF
--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/codecoverage/deployment.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/codecoverage/deployment.yaml
@@ -23,9 +23,6 @@ spec:
         - image: {{ .Values.codecov.imageName }}:{{ .Values.codecov.imageTag }}
           imagePullPolicy: Always
           name: codecov-{{ .Values.codecov.branch }}
-          env:
-          - name: CONTEXTROOT
-            value: {{ .Values.codecov.branch }}/codecov
           ports:
             - containerPort: 80
 {{ end }}

--- a/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/codecoverage/ingress.yaml
+++ b/infrastructure/ibmcloud-galasadev-cluster/galasa-development/branch-maven-repository/templates/codecoverage/ingress.yaml
@@ -24,6 +24,6 @@ spec:
             name: codecov-{{ .Values.codecov.branch }}
             port:
               number: 80
-        path: /{{ .Values.codecov.branch }}/codecov
+        path: /codecoverage
         pathType: Prefix
 {{ end }}

--- a/pipelines/pipelines/codecoverage/codecoverage.yaml
+++ b/pipelines/pipelines/codecoverage/codecoverage.yaml
@@ -212,7 +212,7 @@ spec:
         - --override
         - galasaecosystem.runtime.repository=http://development.galasa.dev/$(params.branch)/maven-repo/obr
         - --override
-        - galasaecosystem.docker.version=codecov
+        - galasaecosystem.docker.version=$(params.branch)
         - --override
         - java.jacoco.code.coverage=true
         - --override


### PR DESCRIPTION
- I have fixed the path in the Ingress and the codecoverage report is now being deployed. 

- I have also removed setting the environment variable CONTEXTROOT in the Deployment as it doesn't do anything. I exec'd into the galasa-codecoverage image and looked at the httpd.conf file and it says `Alias "//codecoverage" "/usr/local/apache2/htdocs` where it should say `Alias "/${CONTEXTROOT}" "/usr/local/apache2/htdocs` - allowing you to set the environment variable. This means the path is being hard coded to /codecoverage instead of being substituted with the CONTEXTROOT value. We could fix this in future but not urgent > (Line 265 https://github.com/galasa-dev/obr/blob/main/codecoveragetemplates/httpd.conf#L265)

- The galasaecosystem.docker.version should not be hard coded, it should match the branch parameter.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>