### PR TITLE
Set jacocoenabled to true as default for Main builds

### DIFF
--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -28,7 +28,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -28,7 +28,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -28,7 +28,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -28,7 +28,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -28,7 +28,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"

--- a/pipelines/pipelines/wrapping/build-branch.yaml
+++ b/pipelines/pipelines/wrapping/build-branch.yaml
@@ -25,7 +25,7 @@ spec:
     default: main-maven-repos
   - name: jacocoEnabled
     type: string
-    default: "false"
+    default: "true"
   - name: isRelease
     type: string
     default: "false"


### PR DESCRIPTION
This is needed so jacoco is ran and the 'codecoverage' directory is deployed in the maven repositories.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>