### PR TITLE
Fix kubectl task

### DIFF
--- a/pipelines/tasks/kubectl.yaml
+++ b/pipelines/tasks/kubectl.yaml
@@ -15,5 +15,4 @@ spec:
     image: harbor.galasa.dev/common/kubectl:main
     imagePullPolicy: Always
     args:
-    - kubectl
     - $(params.command)


### PR DESCRIPTION
- Remove 'kubectl' from the start of the command executed by the kubectl Task, because this is implicitly called from the image by the "ENTRYPOINT" value. This was causing 'kubectl kubectl' to be executed here http://localhost:8001/api/v1/namespaces/tekton-pipelines/services/tekton-dashboard:http/proxy/#/namespaces/galasa-build/pipelineruns/recycle-ecosystem-thr8k?pipelineTask=recycle-api&step=kubectl . This should fix this.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>