### PR TITLE
Fix release PipelineRuns and OBR PR Pipeline

### DIFF
--- a/pipelines/pipelines/obr/build-pr.yaml
+++ b/pipelines/pipelines/obr/build-pr.yaml
@@ -213,7 +213,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/obr/galasa-bom
     - name: settingsLocation
-      value: /workspace/git/$(context.pipelineRun.name)/obr/gpg/settings.xml
+      value: /workspace/git/gpg/settings.xml
     - name: buildArgs
       value:
         - "-Dgpg.skip=true"
@@ -277,7 +277,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/obr/dev.galasa.uber.obr
     - name: settingsLocation
-      value: /workspace/git/$(context.pipelineRun.name)/obr/gpg/settings.xml
+      value: /workspace/git/gpg/settings.xml
     - name: buildArgs
       value:
         - "-Dgpg.skip=true"
@@ -351,7 +351,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/obr/javadocs
     - name: settingsLocation
-      value: /workspace/git/$(context.pipelineRun.name)/obr/settings.xml
+      value: /workspace/git/gpg/settings.xml
     - name: command
       value: 
         - deploy

--- a/releasePipeline/21-build-cli.yaml
+++ b/releasePipeline/21-build-cli.yaml
@@ -13,7 +13,7 @@ metadata:
 #
 spec:
   params:
-  - name: toBranch
+  - name: branch
     value: release
   - name: revision
     value: release
@@ -32,6 +32,23 @@ spec:
 #
 #
 #
+  podTemplate:
+    volumes:
+    - name: gradle-properties
+      secret:
+        secretName: gradle-properties
+    - name: gpg-key
+      secret:
+        secretName: gpg-key
+    - name: mavengpg
+      secret:
+        secretName: mavengpg
+    - name: githubcreds
+      secret:
+        secretName: github-token
+    - name: harborcreds
+      secret:
+        secretName: harbor-creds-yaml
   workspaces:
   - name: git-workspace
     volumeClaimTemplate:

--- a/releasePipeline/50-tag-galasa.yaml
+++ b/releasePipeline/50-tag-galasa.yaml
@@ -25,6 +25,9 @@ spec:
     - name: githubcreds
       secret:
         secretName: github-token
+    - name: harborcreds
+      secret:
+        secretName: harbor-creds-yaml
 
   params:
   - name: distBranch


### PR DESCRIPTION
Main changes:
- The build-cli PipelineRun was missing various secrets which have now been added. It was also using the `toBranch` parameter rather than the `branch` parameter expected in the branch-cli Pipeline.
- Added the harborcreds secret to the tag-galasa PipelineRun which was missing.
- The build-pr Pipeline for the OBR repo was pointing at the old settings.xml location - this has been updated to point at the new location.