### PR TITLE
Include openapi.yaml in maven repos

### DIFF
--- a/dockerfiles/framework/framework-dockerfile
+++ b/dockerfiles/framework/framework-dockerfile
@@ -4,3 +4,4 @@ FROM ${dockerRepository}/galasadev/galasa-maven:${tag}
 
 COPY repo/ /usr/local/apache2/htdocs/
 COPY framework.githash /usr/local/apache2/htdocs/framework.githash
+COPY openapi.yaml /usr/local/apache2/htdocs/openapi.yaml


### PR DESCRIPTION
Removes the need to have the framework cloned in order to access the openapi.yaml file (e.g. CLI repo needs framework in its build-locally script to get the openapi.yaml file. This PR should allow it to download the file from the published maven repos).