### PR TITLE
Bump openapi-generator-cli to 6.1.0

### DIFF
--- a/dockerfiles/common/openapi-dockerfile
+++ b/dockerfiles/common/openapi-dockerfile
@@ -1,4 +1,4 @@
 FROM docker.io/library/openjdk:11
 
 RUN mkdir /opt/openapi
-RUN curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.1/openapi-generator-cli-6.0.1.jar -o /opt/openapi/openapi-generator-cli.jar
+RUN curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.1.0/openapi-generator-cli-6.1.0.jar -o /opt/openapi/openapi-generator-cli.jar


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1406