### PR TITLE
Wrapping and Maven need settings.xml in a different directory

### DIFF
--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -118,6 +118,8 @@ spec:
     params:
     - name: context 
       value: $(context.pipelineRun.name)/maven/galasa-maven-plugin
+    - name: settingsDirectory
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -133,7 +135,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/maven/galasa-maven-plugin
     - name: settingsLocation
-      value: /workspace/git/gpg/settings.xml
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg/settings.xml
     - name: buildArgs
       value: 
         - "-Dgalasa.source.repo=https://repo.maven.apache.org/maven2/"

--- a/pipelines/pipelines/maven/build-pr.yaml
+++ b/pipelines/pipelines/maven/build-pr.yaml
@@ -98,6 +98,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)/maven/galasa-maven-plugin
+    - name: settingsDirectory
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -110,7 +112,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/maven/galasa-maven-plugin
     - name: settingsLocation
-      value: /workspace/git/gpg/settings.xml
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg/settings.xml
     - name: buildArgs
       value:
         - "-Dgpg.skip=true"

--- a/pipelines/pipelines/wrapping/build-branch.yaml
+++ b/pipelines/pipelines/wrapping/build-branch.yaml
@@ -118,6 +118,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)/wrapping
+    - name: settingsDirectory
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -133,7 +135,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/wrapping
     - name: settingsLocation
-      value: /workspace/git/gpg/settings.xml
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg/settings.xml
     - name: buildArgs
       value:
         - "-Dgalasa.source.repo=https://repo.maven.apache.org/maven2/"

--- a/pipelines/pipelines/wrapping/build-pr.yaml
+++ b/pipelines/pipelines/wrapping/build-pr.yaml
@@ -98,6 +98,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)/wrapping
+    - name: settingsDirectory
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -110,7 +112,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/wrapping
     - name: settingsLocation
-      value: /workspace/git/gpg/settings.xml
+      value: /workspace/git/$(context.pipelineRun.name)/maven/galasa-maven-plugin/gpg/settings.xml
     - name: buildArgs
       value:
         - "-Dgpg.skip=true"

--- a/pipelines/tasks/maven-gpg.yaml
+++ b/pipelines/tasks/maven-gpg.yaml
@@ -13,6 +13,9 @@ spec:
   params:
   - name: context
     type: string  
+  - name: settingsDirectory
+    type: string
+    default: /workspace/git/gpg
   steps:
   - name: gpgdirectory
     workingDir: /workspace/git/$(params.context)
@@ -20,7 +23,7 @@ spec:
     imagePullPolicy: Always
     command:
     - mkdir
-    - /workspace/git/gpg
+    - $(params.settingsDirectory)
   - name: import-gpg
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/common/gpg:main
@@ -28,7 +31,7 @@ spec:
     command:
     - gpg
     - --homedir
-    - /workspace/git/gpg
+    - $(params.settingsDirectory)
     - --pinentry-mode
     - loopback
     - --passphrase-file
@@ -45,7 +48,7 @@ spec:
     command:
     - cp
     - /root/mavengpg/settings.xml
-    - /workspace/git/gpg/settings.xml
+    - $(params.settingsDirectory)/settings.xml
     volumeMounts:
     - name: mavengpg
       mountPath: /root/mavengpg 


### PR DESCRIPTION
If Wrapping and Maven have their settings.xml in /workspace/git/gpg for some reason that is deemed unsafe by GPG. All the other pipelines are okay with this so have kept /workspace/git/gpg as the default, but overridden in Wrapping and Maven.


Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>