### PR TITLE
Downgrading the Ubuntu version used in GPG image to try get signing w…

### DIFF
--- a/dockerfiles/common/gpg-dockerfile
+++ b/dockerfiles/common/gpg-dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:latest
+FROM docker.io/library/ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 RUN apt-get update && apt-get install -y unzip \


### PR DESCRIPTION
…orking again

- We also shouldn't be using the latest tag as this means if the 'latest' image is changed the result of our builds change when we have not changed anything.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>