### PR TITLE
Bump openapi-generator-cli to 6.6.0

### DIFF
--- a/dockerfiles/common/openapi-dockerfile
+++ b/dockerfiles/common/openapi-dockerfile
@@ -1,4 +1,4 @@
 FROM docker.io/library/openjdk:11
 
 RUN mkdir /opt/openapi
-RUN curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.1.0/openapi-generator-cli-6.1.0.jar -o /opt/openapi/openapi-generator-cli.jar
+RUN curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.6.0/openapi-generator-cli-6.6.0.jar -o /opt/openapi/openapi-generator-cli.jar

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -146,6 +146,7 @@ spec:
         - -o
         - pkg/galasaapi
         - --additional-properties=packageName=galasaapi
+        - --global-property=apiTests=false
     workspaces:
      - name: git-workspace
        workspace: git-workspace         

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -162,6 +162,7 @@ spec:
         - -o
         - pkg/galasaapi
         - --additional-properties=packageName=galasaapi
+        - --global-property=apiTests=false
     workspaces:
      - name: git-workspace
        workspace: git-workspace         


### PR DESCRIPTION
Part of https://github.com/galasa-dev/projectmanagement/issues/1407
Required for https://github.com/galasa-dev/cli/pull/92

- Version 6.6.0 of openapi-generator-cli correctly generates API client code to download a file from a REST API (6.1.0 contained a bug where file downloads returned nil).
  - The new version also generates tests for the generated API client but these tests fail as they require an API server to be up so that they can execute requests against it. Disabling the generation of these tests for now.