### PR TITLE
Fix parameters being passed through the chain

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -488,15 +488,11 @@ spec:
       - --prefix-name 
       - trigger-eclipse-$(params.toBranch)
       - --param
-      - toBranch=$(params.toBranch)
-      - --param
       - fromObrBranch=$(params.toBranch)
       - --param
       - fromSimplatformBranch=$(params.fromSimplatformBranch)
       - --param
-      - fromJavadocBranch=$(params.toBranch)
-      - --param
-      - fromEclipseBranch=$(params.toBranch)
+      - toBranch=$(params.toBranch)
       - --param
       - revision=$(params.revision)
       - --param
@@ -505,6 +501,7 @@ spec:
       - imageTag=$(params.imageTag)
       - --param
       - appnameMavenRepos=$(params.appnameMavenRepos)
+      - --use-param-defaults # This will pick up the default Eclipse version we have set
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
       - --pod-template

--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -306,15 +306,15 @@ spec:
       - --prefix-name 
       - trigger-isolated-$(params.toBranch)
       - --param
-      - toBranch=$(params.toBranch)
+      - fromObrBranch=$(params.fromObrBranch)
       - --param
       - fromSimplatformBranch=$(params.fromSimplatformBranch)
-      - --param
-      - fromObrBranch=$(params.fromObrBranch)
       - --param
       - fromJavadocBranch=$(params.toBranch)
       - --param
       - fromEclipseBranch=$(params.toBranch)
+      - --param
+      - toBranch=$(params.toBranch)
       - --param
       - revision=$(params.revision)
       - --param

--- a/pipelines/pipelines/obr-generic/build-branch.yaml
+++ b/pipelines/pipelines/obr-generic/build-branch.yaml
@@ -328,8 +328,6 @@ spec:
       - --prefix-name 
       - trigger-cli-$(params.toBranch)
       - --param
-      - fromSimplatformBranch=$(params.fromSimplatformBranch)
-      - --param
       - toBranch=$(params.toBranch)
       - --param
       - revision=$(params.revision)
@@ -339,6 +337,8 @@ spec:
       - imageTag=$(params.imageTag)
       - --param
       - appnameCli=$(params.toBranch)-cli
+      - --param
+      - fromSimplatformBranch=$(params.fromSimplatformBranch)
       - --param
       - appnameMavenRepos=$(params.appname)
       - --workspace


### PR DESCRIPTION
- Remove the passing through of parameters to Eclipse that don't exist as this throws an error
- Set --use-param-defaults which forces the pipeline to use defaults for parameters that haven't been overridden, so here it will pick up the default Eclipse version, so we only have to keep that up to date in the Eclipse pipeline
- Rearrange order of params to match the Pipeline spec so more readable

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>