### PR TITLE
Always pull image in general-command task

### DIFF
--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -22,5 +22,6 @@ spec:
   - name: command
     workingDir: /workspace/git/$(params.context)
     image: $(params.image)
+    imagePullPolicy: Always
     command:
       - $(params.command[*])


### PR DESCRIPTION
Signed-off-by: Eamonn Mansour <47121388+eamansour@users.noreply.github.com>

The `imagePullPolicy` for the general-command task currently defaults to `IfNotPresent`, so if there are changes to an image, these will not be pulled in. This change will ensure images are always pulled.