### PR TITLE
turn on --info when building managers so we can diagnose failures easier

### DIFF
--- a/pipelines/pipelines/managers/build-pr.yaml
+++ b/pipelines/pipelines/managers/build-pr.yaml
@@ -107,6 +107,7 @@ spec:
       value: 
         - check
         - publish
+        - "--info"
     workspaces:
      - name: git-workspace
        workspace: git-workspace


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
