### PR TITLE
Change parameter isRelease to isMainOrRelease

### DIFF
--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -29,9 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -124,7 +124,7 @@ spec:
         - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/extensions/repo"
         - "-PjacocoEnabled=$(params.jacocoEnabled)"
-        - "-PisRelease=$(params.isRelease)"
+        - "-PisMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
       - check
@@ -236,7 +236,7 @@ spec:
       - --param
       - jacocoEnabled=$(params.jacocoEnabled)
       - --param
-      - isRelease=$(params.isRelease)
+      - isMainOrRelease=$(params.isMainOrRelease)
       - --use-param-defaults # This forces Tekton to use the default params of any we haven't passed in
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -29,9 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -124,7 +124,7 @@ spec:
         - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/framework/repo"
         - "-PjacocoEnabled=$(params.jacocoEnabled)"
-        - "-PisRelease=$(params.isRelease)"
+        - "-PisMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - check
@@ -328,7 +328,7 @@ spec:
       - --param
       - jacocoEnabled=$(params.jacocoEnabled)
       - --param
-      - isRelease=$(params.isRelease)
+      - isMainOrRelease=$(params.isMainOrRelease)
       - --use-param-defaults # This forces Tekton to use the default params of any we haven't passed in
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -29,9 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -130,7 +130,7 @@ spec:
         - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/gradle/repo"
         - "-PjacocoEnabled=$(params.jacocoEnabled)"
-        - "-PisRelease=$(params.isRelease)"
+        - "-PisMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - check
@@ -242,7 +242,7 @@ spec:
       - --param
       - jacocoEnabled=$(params.jacocoEnabled)
       - --param
-      - isRelease=$(params.isRelease)
+      - isMainOrRelease=$(params.isMainOrRelease)
       - --use-param-defaults # This forces Tekton to use the default params of any we haven't passed in
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -29,9 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -126,7 +126,7 @@ spec:
         - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/managers/repo"
         - "-PjacocoEnabled=$(params.jacocoEnabled)"
-        - "-PisRelease=$(params.isRelease)"
+        - "-PisMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - check

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -29,9 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -140,7 +140,7 @@ spec:
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/maven/repo"
         - "-Dgalasa.jacocoEnabled=$(params.jacocoEnabled)"
-        - "-Dgalasa.isRelease=$(params.isRelease)"
+        - "-Dgalasa.isMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - deploy
@@ -251,7 +251,7 @@ spec:
       - --param
       - jacocoEnabled=$(params.jacocoEnabled)
       - --param
-      - isRelease=$(params.isRelease)
+      - isMainOrRelease=$(params.isMainOrRelease)
       - --use-param-defaults # This forces Tekton to use the default params of any we haven't passed in
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/pipelines/pipelines/wrapping/build-branch.yaml
+++ b/pipelines/pipelines/wrapping/build-branch.yaml
@@ -26,9 +26,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
-  - name: isRelease
+  - name: isMainOrRelease
     type: string
-    default: "false"
+    default: "true"
   workspaces:
   - name: git-workspace
 # 
@@ -140,7 +140,7 @@ spec:
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/wrapping/repo"
         - "-Dgalasa.jacocoEnabled=$(params.jacocoEnabled)"
-        - "-Dgalasa.isRelease=$(params.isRelease)"
+        - "-Dgalasa.isMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - deploy
@@ -251,7 +251,7 @@ spec:
       - --param
       - jacocoEnabled=$(params.jacocoEnabled)
       - --param
-      - isRelease=$(params.isRelease)
+      - isMainOrRelease=$(params.isMainOrRelease)
       - --use-param-defaults # This forces Tekton to use the default params of any we haven't passed in
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/releasePipeline/20-build-galasa.yaml
+++ b/releasePipeline/20-build-galasa.yaml
@@ -22,7 +22,7 @@ spec:
     value: release-maven-repos
   - name: jacocoEnabled
     value: "false"
-  - name: isRelease
+  - name: isMainOrRelease
     value: "true"
 # 
 # 

--- a/releasePipeline/README.md
+++ b/releasePipeline/README.md
@@ -40,7 +40,7 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 2. Complete Steps 1, 3 and 4 of the 'Create branch and ArgoCD applications' section in the release process
    - Before doing Step 1, in 02-create-argocd-apps.sh, do a find and replace on the word 'release' and change to 'prerelease'. 
    - In Step 4, **ensure that the following parameters are set**: distBranch=prerelease, fromBranch=main
-3. Complete Step 1 of 'Build the components' **ensuring that the following parameters are set**: toBranch=prerelease, revision=prerelease, refspec=refs/heads/prerelease:refs/heads/prerelease, imageTag=prerelease, appname=prerelease-maven-repos, jacocoEnabled=false, isRelease=true
+3. Complete Step 1 of 'Build the components' **ensuring that the following parameters are set**: toBranch=prerelease, revision=prerelease, refspec=refs/heads/prerelease:refs/heads/prerelease, imageTag=prerelease, appname=prerelease-maven-repos, jacocoEnabled=false, isMainOrRelease=true
 4. Go to a maven artifact from each repository and check that the .asc files are present, which means the artifact has been signed. For example, https://development.galasa.dev/prerelease/maven-repo/wrapping/dev/galasa/com.auth0.jwt/<VERSION> should contain a file called com.auth0.jwt-<VERSION>.jar.asc.
 5. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 


### PR DESCRIPTION
Across all pipelines that use this parameter, have changed the build arg isRelease to isMainOrRelease, and changed the default value to true. This will use the value in the relevant gradle files and will tell gradle to complete signing tasks on any builds that are main or release.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>