### PR TITLE
Add comment to make clear what isMainOrRelease is for

### DIFF
--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -29,6 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to the Gradle build script as a build argument later.
+  # When set to true, Gradle will complete signing tasks like signing artifacts with a GPG key.
+  # Should be set to true for Main or Release builds. Set to false if doing a branch build.
   - name: isMainOrRelease
     type: string
     default: "true"

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -29,6 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to the Gradle build script as a build argument later.
+  # When set to true, Gradle will complete signing tasks like signing artifacts with a GPG key.
+  # Should be set to true for Main or Release builds. Set to false if doing a branch build.
   - name: isMainOrRelease
     type: string
     default: "true"

--- a/pipelines/pipelines/gradle/build-branch.yaml
+++ b/pipelines/pipelines/gradle/build-branch.yaml
@@ -29,6 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to the Gradle build script as a build argument later.
+  # When set to true, Gradle will complete signing tasks like signing artifacts with a GPG key.
+  # Should be set to true for Main or Release builds. Set to false if doing a branch build.
   - name: isMainOrRelease
     type: string
     default: "true"

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -29,6 +29,9 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to the Gradle build script as a build argument later.
+  # When set to true, Gradle will complete signing tasks like signing artifacts with a GPG key.
+  # Should be set to true for Main or Release builds. Set to false if doing a branch build.
   - name: isMainOrRelease
     type: string
     default: "true"

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -29,6 +29,8 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to any Gradle build script as a build argument later.
+  # Not used in this pipeline as is a Maven build but needs passing through to the next build for the Framework repository.
   - name: isMainOrRelease
     type: string
     default: "true"
@@ -140,7 +142,6 @@ spec:
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/maven/repo"
         - "-Dgalasa.jacocoEnabled=$(params.jacocoEnabled)"
-        - "-Dgalasa.isMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - deploy

--- a/pipelines/pipelines/wrapping/build-branch.yaml
+++ b/pipelines/pipelines/wrapping/build-branch.yaml
@@ -26,6 +26,8 @@ spec:
   - name: jacocoEnabled
     type: string
     default: "true"
+  # isMainOrRelease accepts a true or false value which is passed to any Gradle build script as a build argument later.
+  # Not used in this pipeline as is a Maven build but needs passing through to the next build for the Gradle repository.
   - name: isMainOrRelease
     type: string
     default: "true"
@@ -140,7 +142,6 @@ spec:
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/wrapping/repo"
         - "-Dgalasa.jacocoEnabled=$(params.jacocoEnabled)"
-        - "-Dgalasa.isMainOrRelease=$(params.isMainOrRelease)"
     - name: command
       value: 
         - deploy


### PR DESCRIPTION
and remove when unused for Maven builds, as Maven builds always sign.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>