### PR TITLE
cleaned code

### DIFF
--- a/offline-tools/copyrighter/README.md
+++ b/offline-tools/copyrighter/README.md
@@ -10,7 +10,7 @@ The tool ensures files have a copyright comment like the one below:<br />
 
 
 ## Files that the tool is able to process
-- Files with /* */ type comments:<br />
+- Files with /* */ or // type comments:<br />
     Java (.java), Go (.go), JavaScript (.js), Sass (.scss), TypeScript (.ts), TypeScript with JSX (.tsx)<br />
 - Files with # type comments:<br />
     Yaml (.yaml), Bash Script (.sh)<br />

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
@@ -34,6 +34,7 @@ const (
 	COMMENT_CONTINUE_JAVA = " *"
 	COMMENT_END_JAVA      = " */"
 	COMMENT_HASH          = "#"
+	COMMENT_STROKE        = "//"
 )
 
 func init() {
@@ -144,7 +145,12 @@ func setCopyright(input string, commentType string) (string, error) {
 	var newLine int
 
 	if commentType == COMMENT_CONTINUE_JAVA { //file contains opening and closing coments
-		inputWithNoCopyright, err, dontAddCopyright = stripOutExistingCopyright(input)
+		//remove any IBM/Galasa double stroke copyright comment
+		input, dontAddCopyright = checkForDoubleStrokeCopyrightComments(input)
+		if !dontAddCopyright { //for any double stroke non-Galasa/IBM comment, skip looking for copyright again
+			inputWithNoCopyright, err, dontAddCopyright = stripOutExistingCopyright(input)
+		}
+
 		if dontAddCopyright {
 			return input, err
 		}
@@ -238,6 +244,50 @@ func stripOutExistingCopyright(input string) (string, error, bool) {
 	return output, err, dontAddCopyright
 }
 
+func checkForDoubleStrokeCopyrightComments(input string) (string, bool) {
+	var output string
+	var firstStroke int
+	var lastStroke int
+	var newLine int
+	var commentToCheck string
+	var dontAddCopyright = false
+
+	if strings.Contains(input, COMMENT_STROKE) {
+		input = strings.TrimSpace(input)
+		firstStroke = strings.Index(input, COMMENT_STROKE)
+		newLine = strings.Index(input, "\n")
+
+		//for leading texts
+		for newLine < firstStroke {
+			newLine += strings.Index(input[firstStroke:], "\n")
+		}
+
+		if !strings.Contains(input[newLine+1:newLine+4], COMMENT_STROKE) { //for one line comment
+			lastStroke = newLine + 1
+		} else { // for multi-line comment
+			for {
+				newLine += strings.Index(input[newLine+1:], "\n") + 1
+				if strings.Contains(input[newLine+1:newLine+3], COMMENT_STROKE) {
+					//move on to find next newLine
+				} else if !strings.Contains(input[newLine+1:newLine+3], COMMENT_STROKE) {
+					lastStroke = newLine
+					break
+				}
+			}
+		}
+
+		commentToCheck = input[firstStroke:lastStroke]
+
+		if copyrightContainsIBMOrGalasa(commentToCheck) {
+			input = strings.ReplaceAll(input, commentToCheck, "")
+		} else if strings.Contains(commentToCheck, "Copyright") {
+			dontAddCopyright = true
+		}
+	}
+	output = input
+	return output, dontAddCopyright
+}
+
 func stripOutExistingCopyrightHash(input string) (string, bool) {
 	var output string
 	var firstHash int
@@ -274,6 +324,7 @@ func stripOutExistingCopyrightHash(input string) (string, bool) {
 	commentToCheck = input[firstHash:lastHash]
 
 	if commentNeedsNoChange(commentToCheck) {
+		print("true")
 		dontAddCopyright = true
 		output = input
 	} else {
@@ -281,13 +332,13 @@ func stripOutExistingCopyrightHash(input string) (string, bool) {
 			if leadingText != "" {
 				output = "\n" + leadingText + input[lastHash+1:]
 			} else {
-				output = input[lastHash:]
+				output = "\n" + input[lastHash:]
 			}
 		} else if strings.Contains(commentToCheck, "Copyright") { //copyright of external party
 			dontAddCopyright = true
 			output = input
 		} else {
-			output = input
+			output = "\n" + input
 		}
 	}
 
@@ -335,12 +386,10 @@ func findNextNoneWhiteSpaceCharacter(input string, startIndexOfFollowingInput in
 }
 
 func commentNeedsNoChange(commentToCheck string) bool {
-	standardCopyright := `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`
-	return commentToCheck == standardCopyright
+	if strings.Contains(commentToCheck, "# Copyright contributors to the Galasa project") && strings.Contains(commentToCheck, "# SPDX-License-Identifier: EPL-2.0") {
+		return true
+	}
+	return false
 }
 
 func fileIsBashScript(firstLineToCheck string) bool {

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
@@ -390,10 +390,12 @@ func findNextNoneWhiteSpaceCharacter(input string, startIndexOfFollowingInput in
 }
 
 func commentNeedsNoChange(commentToCheck string) bool {
-	if strings.Contains(commentToCheck, "# Copyright contributors to the Galasa project") && strings.Contains(commentToCheck, "# SPDX-License-Identifier: EPL-2.0") {
-		return true
-	}
-	return false
+	standardCopyright := `#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`
+	return commentToCheck == strings.TrimSpace(standardCopyright)
 }
 
 func fileIsBashScript(firstLineToCheck string) bool {

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
@@ -395,7 +395,7 @@ func commentNeedsNoChange(commentToCheck string) bool {
 #
 # SPDX-License-Identifier: EPL-2.0
 #`
-	return commentToCheck == strings.TrimSpace(standardCopyright)
+	return strings.TrimSpace(commentToCheck) == standardCopyright
 }
 
 func fileIsBashScript(firstLineToCheck string) bool {

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter.go
@@ -262,11 +262,17 @@ func checkForDoubleStrokeCopyrightComments(input string) (string, bool) {
 			newLine += strings.Index(input[firstStroke:], "\n")
 		}
 
+		//finding where the comment ends
 		if !strings.Contains(input[newLine+1:newLine+4], COMMENT_STROKE) { //for one line comment
 			lastStroke = newLine + 1
 		} else { // for multi-line comment
 			for {
+				if !strings.Contains(input[newLine+1:], "\n") {
+					lastStroke = len(input)
+					break
+				}
 				newLine += strings.Index(input[newLine+1:], "\n") + 1
+
 				if strings.Contains(input[newLine+1:newLine+3], COMMENT_STROKE) {
 					//move on to find next newLine
 				} else if !strings.Contains(input[newLine+1:newLine+3], COMMENT_STROKE) {
@@ -306,25 +312,23 @@ func stripOutExistingCopyrightHash(input string) (string, bool) {
 		leadingText = input[:newLine]
 		newLine += strings.Index(input[firstHash:], "\n")
 	}
-
-	if input[newLine+1] != '#' { //for one line comment
-		lastHash = newLine
-	} else { // for multi-line comment
-		for {
-			newLine += strings.Index(input[newLine+1:], "\n") + 1
-			if input[newLine+1] == '#' {
-				//move on to find next newLine
-			} else if input[newLine+1] != '#' {
-				lastHash = newLine
+	//finding where the comment ends
+	for {
+		if input[newLine+1] != '#' {
+			lastHash = newLine
+			break
+		} else {
+			if !strings.Contains(input[newLine+1:], "\n") {
+				lastHash = len(input)
 				break
 			}
+			newLine += strings.Index(input[newLine+1:], "\n") + 1
 		}
 	}
 
 	commentToCheck = input[firstHash:lastHash]
 
 	if commentNeedsNoChange(commentToCheck) {
-		print("true")
 		dontAddCopyright = true
 		output = input
 	} else {

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter_test.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter_test.go
@@ -416,6 +416,41 @@ package mypackage`
 	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
 }
 
+func TestWholeFileIsACopyrightCommentToBeReplacedDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `//
+//Copyright contributors to Galasa
+//
+//remove me!`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa")
+	assert.NotContains(t, output, "//remove me!")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestWholeFileContainsCommentsWithACopyrightCommentToBeReplacesDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `//
+//Copyright contributors to Galasa
+//
+
+//don't remove me!`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa")
+	assert.Contains(t, output, "//don't remove me!")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
 func TestReplaceOneLineCopyrightHashCommentYaml(t *testing.T) {
 	// Given..
 	var input = `# Copyright contributors to the Galasa project
@@ -630,8 +665,50 @@ func TestOnlyHasCommentsAndNoneToBeRemovedYaml(t *testing.T) {
 
 	// Then..
 	assert.NotNil(t, output)
-	assert.Contains(t, output, "leading text")
-	assert.Contains(t, output, "package mypackage")
+	assert.Contains(t, output, "#leading text")
+	assert.Contains(t, output, "#package mypackage")
+	if !strings.HasPrefix(output, `#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
+		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
+	}
+}
+func TestWholeContentIsACommentWithCopyrightToBeRemovedYaml(t *testing.T) {
+	// Given..
+	var input = `#Copyright and IBM
+#
+#package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, "#")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "Copyright and IBM")
+	assert.NotContains(t, output, "#package mypackage")
+	if !strings.HasPrefix(output, `#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
+		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
+	}
+}
+
+func TestWholeContentIsACommentNoCopyrightToBeRemovedYaml(t *testing.T) {
+	// Given..
+	var input = `#sgdg
+#
+#package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, "#")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.Contains(t, output, "#package mypackage")
 	if !strings.HasPrefix(output, `#
 # Copyright contributors to the Galasa project
 #
@@ -653,7 +730,7 @@ func TestOnlyHasCommentsAndCopyrightCommentToBeRemovedYaml(t *testing.T) {
 	// Then..
 	assert.NotNil(t, output)
 	assert.NotContains(t, output, "Copyright and IBM")
-	assert.Contains(t, output, "package mypackage")
+	assert.Contains(t, output, "#package mypackage")
 	if !strings.HasPrefix(output, `#
 # Copyright contributors to the Galasa project
 #
@@ -677,6 +754,7 @@ func TestSpaceAtStartOfFileWIthCopyrightHashCommentToBeRemovedYaml(t *testing.T)
 	assert.NotNil(t, output)
 	assert.NotContains(t, output, "Copyright and IBM")
 	assert.Contains(t, output, "package mypackage")
+	assert.Contains(t, output, "# SPDX-License-Identifier: EPL-2.0")
 }
 
 func TestSingleCopyrightCommentToBeRemovedWithLeadingAndClosingHashYaml(t *testing.T) {
@@ -684,6 +762,7 @@ func TestSingleCopyrightCommentToBeRemovedWithLeadingAndClosingHashYaml(t *testi
 	var input = `#
 # Copyright contributors to the Galasa project 
 #
+
 apiVersion: apps/v1`
 
 	// When...
@@ -691,7 +770,8 @@ apiVersion: apps/v1`
 
 	// Then..
 	assert.NotNil(t, output)
-	assert.Contains(t, output, "#\n\napiVersion")
+	assert.Contains(t, output, "\n\napiVersion")
+	assert.Contains(t, output, "# SPDX-License-Identifier: EPL-2.0")
 }
 
 func TestCopyrightCommentIsNotToBeRemovedYaml(t *testing.T) {

--- a/offline-tools/copyrighter/pkg/cmd/galasacopyrighter_test.go
+++ b/offline-tools/copyrighter/pkg/cmd/galasacopyrighter_test.go
@@ -15,10 +15,10 @@ import (
 
 func TestCanAddCopyrightWhenNoneExistsAlready(t *testing.T) {
 	var input = `package mypackage
-	 class AClass {
-		 // Does nothing.
-	 }
-	 `
+	class AClass {
+		// Does nothing.
+	}
+	`
 
 	output, err := setCopyright(input, " *")
 
@@ -26,10 +26,10 @@ func TestCanAddCopyrightWhenNoneExistsAlready(t *testing.T) {
 	assert.Nil(t, err)
 
 	if !strings.HasPrefix(output, `/*
-  * Copyright contributors to the Galasa project
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */`) {
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */`) {
 		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
 	}
 }
@@ -37,10 +37,10 @@ func TestCanAddCopyrightWhenNoneExistsAlready(t *testing.T) {
 func TestCopyrightAddedToOriginalContent(t *testing.T) {
 	// Given..
 	var input = `package mypackage
-	 class AClass {
-		 // Does nothing.
-	 }
-	 `
+	class AClass {
+		// Does nothing.
+	}
+	`
 
 	// When...
 	output, err := setCopyright(input, " *")
@@ -56,15 +56,15 @@ func TestCopyrightAddedToOriginalContent(t *testing.T) {
 func TestCopyrightNotAddedWhenPresentAlready(t *testing.T) {
 	// Given..
 	var input = `/*
-  * Copyright contributors to the Galasa project
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */
- package mypackage
- class AClass {
-	 // Does nothing.
- }
- `
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package mypackage
+class AClass {
+	// Does nothing.
+}
+`
 
 	// When...
 	output, err := setCopyright(input, " *")
@@ -83,10 +83,10 @@ func TestCopyrightNotAddedWhenPresentAlready(t *testing.T) {
 func TestCopyrightWhereNoneExistsAddedToStartOfFile(t *testing.T) {
 	// Given..
 	var input = `package mypackage
-	 class AClass {
-		 // Does nothing.
-	 }
-	 `
+	class AClass {
+		// Does nothing.
+	}
+	`
 
 	// When...
 	output, err := setCopyright(input, " *")
@@ -99,10 +99,10 @@ func TestCopyrightWhereNoneExistsAddedToStartOfFile(t *testing.T) {
 func TestCanStripOutFirstCommentAndTrailingWhiteSpace(t *testing.T) {
 	// Given..
 	var input = `/*
-  * Copyright line here IBM
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */       ` + "\t" + "\n" + "package mypackage"
+ * Copyright line here IBM
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */       ` + "\t" + "\n" + "package mypackage"
 
 	// When...
 	output, err, _ := stripOutExistingCopyright(input)
@@ -130,9 +130,9 @@ func TestCanStripOutFirstCommentWhenThereIsNoComment(t *testing.T) {
 func TestCanStripOutFirstCommentMostCommonExistingCopyrightStatement(t *testing.T) {
 	// Given..
 	var input = `/*
-  * Copyright in Galasa file
-  */
-  package mypackage`
+ * Copyright in Galasa file
+ */
+package mypackage`
 
 	// When...
 	output, err, _ := stripOutExistingCopyright(input)
@@ -147,10 +147,10 @@ func TestCanStripOutFirstCommentMostCommonExistingCopyrightStatement(t *testing.
 func TestCanStripOutFirstCommentLeadingTextShouldBePreserved(t *testing.T) {
 	// Given..
 	var input = `leading text here
- /*
-  * Copyright contributors to the Galasa project
-  */
-  package mypackage`
+/*
+ * Copyright contributors to the Galasa project
+ */
+package mypackage`
 
 	// When...
 	output, err, _ := stripOutExistingCopyright(input)
@@ -164,10 +164,10 @@ func TestCanStripOutFirstCommentLeadingTextShouldBePreserved(t *testing.T) {
 func TestStrippingOutFirstCommentWithNoClosingTagFailsWithError(t *testing.T) {
 	// Given..
 	var input = `
- /*
-  * Copyright is Galasa found here
- 
-  package mypackage`
+/*
+ * Copyright is Galasa found here
+
+package mypackage`
 
 	// When...
 	_, err, _ := stripOutExistingCopyright(input)
@@ -180,10 +180,10 @@ func TestStrippingOutFirstCommentWithNoClosingTagFailsWithError(t *testing.T) {
 func TestClosingCommentIsBeforeOpeningCommentFailsWithError(t *testing.T) {
 	// Given..
 	var input = `
- */
-  * Copyright contributors to the Galasa project
-  /*
-  package mypackage`
+*/
+ * Copyright contributors to the Galasa project
+/*
+package mypackage`
 
 	// When...
 	_, err, _ := stripOutExistingCopyright(input)
@@ -196,10 +196,10 @@ func TestClosingCommentIsBeforeOpeningCommentFailsWithError(t *testing.T) {
 func TestCommentIsPresentButDoesNotIncludeCopyrightToBeRemoved(t *testing.T) {
 	// Given..
 	var input = `
- /*
-  * Hello, World Copyright
-  */
-  package mypackage`
+/*
+ * Hello, World Copyright
+ */
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -213,10 +213,10 @@ func TestCommentIsPresentButDoesNotIncludeCopyrightToBeRemoved(t *testing.T) {
 func TestCommentDoesNotIncludeCopyrightToBeRemovedButStartsWithClosingComment(t *testing.T) {
 	// Given..
 	var input = `
- */
-  * Hello, World
-  /*
-  package mypackage`
+*/
+ * Hello, World
+/*
+package mypackage`
 
 	// When...
 	_, err := setCopyright(input, " *")
@@ -229,10 +229,10 @@ func TestCommentDoesNotIncludeCopyrightToBeRemovedButStartsWithClosingComment(t 
 func TestCommentIsPresentAndIncludesCopyrightToBeRemoved(t *testing.T) {
 	// Given..
 	var input = `
- /*
-  * Copyright IBM is found here
-  */
-  package mypackage`
+/*
+ * Copyright IBM is found here
+ */
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -246,10 +246,10 @@ func TestCommentIsPresentAndIncludesCopyrightToBeRemoved(t *testing.T) {
 func TestCommentIsPresentButDoesIncludesCopyrightToBeRemovedAndHasLeadingText(t *testing.T) {
 	// Given..
 	var input = `leading text
- /*
-  * IBM is found here
-  */
-  package mypackage`
+/*
+ * IBM is found here
+ */
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -264,11 +264,11 @@ func TestCommentIsPresentButDoesIncludesCopyrightToBeRemovedAndHasLeadingText(t 
 func TestCommentNeedsNoChange(t *testing.T) {
 	// Given..
 	var input = `/*
-  * Copyright contributors to the Galasa project
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */
- package mypackage`
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -281,7 +281,7 @@ func TestCommentNeedsNoChange(t *testing.T) {
 func TestReplaceOneLineCopyrightCommentSCSS_TS_TSXFile(t *testing.T) {
 	// Given..
 	var input = `/*Copyright contributiors of Galasa*/
- package mypackage`
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -295,9 +295,9 @@ func TestReplaceOneLineCopyrightCommentSCSS_TS_TSXFile(t *testing.T) {
 func TestCopyrightCommentIsNotToBeRemoved(t *testing.T) {
 	// Given..
 	var input = `/*
-  * Copyright contributions of Shrek
-  */
- package mypackage`
+ * Copyright contributions of Shrek
+ */
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, " *")
@@ -307,12 +307,121 @@ func TestCopyrightCommentIsNotToBeRemoved(t *testing.T) {
 	assert.Equal(t, output, input)
 }
 
+func TestCopyrightCommentContainsDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `//Copyright contributors to Galasa Project
+//IBM
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa Project")
+	assert.NotContains(t, output, "//IBM")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestCopyrightCommentContainsMultilineDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `//
+//Copyright contributors to Galasa Project
+//
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa Project")
+	assert.NotContains(t, output, "//")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestCopyrightCommentContainsDoubleStrokeWithLeadingText(t *testing.T) {
+	// Given..
+	var input = `leading text here
+//Copyright contributors to Galasa Project
+//copyright of IBM
+//
+
+//don't remove me!
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa Project")
+	assert.NotContains(t, output, "//copyright of IBM")
+	assert.Contains(t, output, "leading text here")
+	assert.Contains(t, output, "//don't remove me!")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestNonCopyrightCommentContainsDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `leading text here
+//Copyright contributors to Shrek
+//
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.Contains(t, output, "//Copyright contributors to Shrek")
+	assert.Contains(t, output, "leading text here")
+	assert.NotContains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestRemoveSingleLineCopyrightCommentDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `leading text here
+//Copyright contributors to Galasa
+
+//don't remove me!
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa")
+	assert.Contains(t, output, "//don't remove me!")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
+func TestRemovesCopyrightCommentAndLeavesFollowingCommentUntouchedDoubleStroke(t *testing.T) {
+	// Given..
+	var input = `leading text here
+//Copyright contributors to Galasa
+//
+
+//don't remove me!
+package mypackage`
+
+	// When...
+	output, _ := setCopyright(input, " *")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.NotContains(t, output, "//Copyright contributors to Galasa")
+	assert.Contains(t, output, "//don't remove me!")
+	assert.Contains(t, output, "* SPDX-License-Identifier: EPL-2.0")
+}
+
 func TestReplaceOneLineCopyrightHashCommentYaml(t *testing.T) {
 	// Given..
 	var input = `# Copyright contributors to the Galasa project
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -322,21 +431,19 @@ func TestReplaceOneLineCopyrightHashCommentYaml(t *testing.T) {
 	assert.NotContains(t, output, "# Copyright contributors to the Galasa project\napiVersion:")
 	assert.Contains(t, output, "# SPDX-License-Identifier: EPL-2.0")
 	assert.Contains(t, output, "apiVersion: v1\nkind: PersistentVolumeClaim")
-
 	assert.Equal(t, 1, strings.Count(output, "Copyright contributors"), "Repeated")
-
 }
 
 func TestReplaceMultipleLineCopyrightWithLeadingAndEndingHashYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributors to the Galasa project
- # Property of IBM
- #
- 
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+# Copyright contributors to the Galasa project
+# Property of IBM
+#
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -352,11 +459,11 @@ func TestReplaceMultipleLineCopyrightWithLeadingAndEndingHashYaml(t *testing.T) 
 func TestReplaceSingleLineCopyrightWithLeadingAndEndingHashYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributors to the Galasa project
- #
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+# Copyright contributors to the Galasa project
+#
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -373,12 +480,12 @@ func TestReplaceSingleLineCopyrightWithLeadingAndEndingHashYaml(t *testing.T) {
 func TestReplaceMultipleLineCopyrightCommentWithoutEndingHashYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributors to the Galasa project
- # Property of IBM
- 
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+# Copyright contributors to the Galasa project
+# Property of IBM
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -395,11 +502,11 @@ func TestReplaceMultipleLineCopyrightCommentWithoutEndingHashYaml(t *testing.T) 
 func TestReplaceMultipleLineCopyrightCommentWithoutLeadingAndEndingHashYaml(t *testing.T) {
 	// Given..
 	var input = `# Copyright contributors to the Galasa project
- # Property of IBM
- 
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+# Property of IBM
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -416,10 +523,10 @@ func TestReplaceMultipleLineCopyrightCommentWithoutLeadingAndEndingHashYaml(t *t
 func TestReplaceCopyrightCommentAtStartOfFileWithLeadingHashButNoOtherCommentsYaml(t *testing.T) {
 	// Given..
 	var input = `#
- Copyright contributors to the Galasa project
- apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+Copyright contributors to the Galasa project
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -435,8 +542,8 @@ func TestReplaceCopyrightCommentAtStartOfFileWithLeadingHashButNoOtherCommentsYa
 func TestAddCopyrightWhereThereIsNoneInYamlFile(t *testing.T) {
 	// Given..
 	var input = `apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:`
+kind: PersistentVolumeClaim
+metadata:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -451,9 +558,9 @@ func TestAddCopyrightWhereThereIsNoneInYamlFile(t *testing.T) {
 func TestDoesNotIncludeCopyrightToBeRemovedButHasLeadingTextYaml(t *testing.T) {
 	// Given..
 	var input = `leading text
-  # IBM is found here
- 
-  package mypackage`
+# IBM is found here
+
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -468,9 +575,9 @@ func TestDoesNotIncludeCopyrightToBeRemovedButHasLeadingTextYaml(t *testing.T) {
 func TestIncludesCopyrightToBeRemovedButHasLeadingTextHashYaml(t *testing.T) {
 	// Given..
 	var input = `leading text
- # Copyright IBM is found here
- 
- package mypackage`
+# Copyright IBM is found here
+
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -480,10 +587,10 @@ func TestIncludesCopyrightToBeRemovedButHasLeadingTextHashYaml(t *testing.T) {
 	assert.Contains(t, output, "leading text")
 	assert.NotContains(t, output, "IBM is found here Copyright")
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
 	}
 
@@ -492,8 +599,8 @@ func TestIncludesCopyrightToBeRemovedButHasLeadingTextHashYaml(t *testing.T) {
 func TestAddCopyrightCommentToStartWheretThereAreNoCommentsTextYaml(t *testing.T) {
 	// Given..
 	var input = `leading text
- 
- package mypackage`
+
+package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -503,10 +610,10 @@ func TestAddCopyrightCommentToStartWheretThereAreNoCommentsTextYaml(t *testing.T
 	assert.Contains(t, output, "leading text")
 	assert.NotContains(t, output, "IBM is found here Copyright")
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
 	}
 
@@ -515,8 +622,8 @@ func TestAddCopyrightCommentToStartWheretThereAreNoCommentsTextYaml(t *testing.T
 func TestOnlyHasCommentsAndNoneToBeRemovedYaml(t *testing.T) {
 	// Given..
 	var input = `#leading text
- 
- #package mypackage`
+
+#package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -526,10 +633,10 @@ func TestOnlyHasCommentsAndNoneToBeRemovedYaml(t *testing.T) {
 	assert.Contains(t, output, "leading text")
 	assert.Contains(t, output, "package mypackage")
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
 	}
 }
@@ -537,8 +644,8 @@ func TestOnlyHasCommentsAndNoneToBeRemovedYaml(t *testing.T) {
 func TestOnlyHasCommentsAndCopyrightCommentToBeRemovedYaml(t *testing.T) {
 	// Given..
 	var input = `#Copyright and IBM
- 
- #package mypackage`
+
+#package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -548,10 +655,10 @@ func TestOnlyHasCommentsAndCopyrightCommentToBeRemovedYaml(t *testing.T) {
 	assert.NotContains(t, output, "Copyright and IBM")
 	assert.Contains(t, output, "package mypackage")
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is not at the start of the output. output:\n%s", output)
 	}
 }
@@ -559,9 +666,9 @@ func TestOnlyHasCommentsAndCopyrightCommentToBeRemovedYaml(t *testing.T) {
 func TestSpaceAtStartOfFileWIthCopyrightHashCommentToBeRemovedYaml(t *testing.T) {
 	// Given..
 	var input = `
- #Copyright and IBM
- 
- #package mypackage`
+#Copyright and IBM
+
+#package mypackage`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -575,9 +682,9 @@ func TestSpaceAtStartOfFileWIthCopyrightHashCommentToBeRemovedYaml(t *testing.T)
 func TestSingleCopyrightCommentToBeRemovedWithLeadingAndClosingHashYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributors to the Galasa project 
- #
- apiVersion: apps/v1`
+# Copyright contributors to the Galasa project 
+#
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -590,9 +697,9 @@ func TestSingleCopyrightCommentToBeRemovedWithLeadingAndClosingHashYaml(t *testi
 func TestCopyrightCommentIsNotToBeRemovedYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributions of Shrek
- #
- apiVersion: apps/v1`
+# Copyright contributions of Shrek
+#
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -605,23 +712,23 @@ func TestCopyrightCommentIsNotToBeRemovedYaml(t *testing.T) {
 func TestCopyrightCommentNeedsNoChangeYaml(t *testing.T) {
 	// Given..
 	var input = `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #
- 
- apiVersion: galasa.dev/v1alpha
- kind: Release
- metadata:
- name: galasa-release
- 
- managers:
- bundles:
- 
- #
- # Manager
- #
-	 `
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+name: galasa-release
+
+managers:
+bundles:
+
+#
+# Manager
+#
+	`
 	// When...
 	output, _ := setCopyright(input, "#")
 
@@ -630,20 +737,36 @@ func TestCopyrightCommentNeedsNoChangeYaml(t *testing.T) {
 	assert.Equal(t, output, input)
 }
 
+func TestAddCopyrightCommentWithSpaceBeforeNextComment(t *testing.T) {
+	// Given..
+	var input = `#where does this?
+apiVersion: galasa.dev/v1alpha
+kind: Release
+metadata:
+name: galasa-release
+	`
+	// When...
+	output, _ := setCopyright(input, "#")
+
+	// Then..
+	assert.NotNil(t, output)
+	assert.Contains(t, output, "#where does this?\napiVersion")
+}
+
 func TestAddCopyrightWhenNoOtherCommentIsPresentYaml(t *testing.T) {
 	// Given..
 	var input = `apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:
- name: galasa-build-source-pvc
- namespace: tekton
-	 spec:
-	 apiVersion: v1
-	 kind: PersistentVolumeClaim
-	 metadata:
-	   name: galasa-build-source-pvc
-	   namespace: tekton
-	 spec:`
+kind: PersistentVolumeClaim
+metadata:
+name: galasa-build-source-pvc
+namespace: tekton
+	spec:
+	apiVersion: v1
+	kind: PersistentVolumeClaim
+	metadata:
+	name: galasa-build-source-pvc
+	namespace: tekton
+	spec:`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -651,10 +774,10 @@ func TestAddCopyrightWhenNoOtherCommentIsPresentYaml(t *testing.T) {
 	// Then..
 	assert.NotNil(t, output)
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is absent", output)
 	}
 	assert.Contains(t, output, "apiVersion: v1\nkind")
@@ -663,23 +786,23 @@ func TestAddCopyrightWhenNoOtherCommentIsPresentYaml(t *testing.T) {
 func TestAddCopyrightWhereThereAreMultipleNonCopyrightHashCommentInFileYaml(t *testing.T) {
 	// Given..
 	var input = `apiVersion: v1
- kind: ConfigMap
- metadata:
-   name: argocd-cm
-   namespace: argocd
-   labels:
-	 app.kubernetes.io/name: argocd-cm
-	 app.kubernetes.io/part-of: argocd
- data:
-	 url: https://argocd.galasa.dev
- #
- #
- #
-   accounts.galasa: "apiKey,login"
-   accounts.galasa.enabled: "true"
- #
- #
- #`
+kind: ConfigMap
+metadata:
+name: argocd-cm
+namespace: argocd
+labels:
+	app.kubernetes.io/name: argocd-cm
+	app.kubernetes.io/part-of: argocd
+data:
+	url: https://argocd.galasa.dev
+#
+#
+#
+accounts.galasa: "apiKey,login"
+accounts.galasa.enabled: "true"
+#
+#
+#`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -687,32 +810,32 @@ func TestAddCopyrightWhereThereAreMultipleNonCopyrightHashCommentInFileYaml(t *t
 	// Then..
 	assert.NotNil(t, output)
 	if !strings.HasPrefix(output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`) {
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`) {
 		assert.Fail(t, "Copyright statement is absent", output)
 	}
 	assert.Contains(t, output, `data:
-	 url: https://argocd.galasa.dev
- #
- #
- #`)
+	url: https://argocd.galasa.dev
+#
+#
+#`)
 	assert.Contains(t, output, "apiVersion: v1\nkind")
 }
 
 func TestAddCopyrightWhenCommentNotToBeReplacedYaml(t *testing.T) {
 	// Given..
 	var input = `#!/bin/bash
- 
- #--------------------------------------------------------------------------
- #
- # Objective: Set environment variables for external ecosystem services
- #
- #--------------------------------------------------------------------------
- 
- #
- # Functions`
+
+#--------------------------------------------------------------------------
+#
+# Objective: Set environment variables for external ecosystem services
+#
+#--------------------------------------------------------------------------
+
+#
+# Functions`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -723,20 +846,19 @@ func TestAddCopyrightWhenCommentNotToBeReplacedYaml(t *testing.T) {
 		assert.Fail(t, "Copyright statement is absent", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, `#--------------------------------------------------------------------------
- #`)
-	println(output)
+#`)
 }
 
 func TestAddCopyrightWhenNoOtherCommentIsPresentBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- 
- apiVersion: apps/v1`
+
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -747,19 +869,19 @@ func TestAddCopyrightWhenNoOtherCommentIsPresentBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestCommentIsPresentButDoesNotContainCopyrightBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- 
- #what is this info here?
- apiVersion: apps/v1`
+
+#what is this info here?
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -770,10 +892,10 @@ func TestCommentIsPresentButDoesNotContainCopyrightBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "#what is this info here?")
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
@@ -781,10 +903,10 @@ func TestCommentIsPresentButDoesNotContainCopyrightBashScript(t *testing.T) {
 func TestReplaceCopyrightBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- 
- #Copyright of IBM
- #and Galasa
- apiVersion: apps/v1`
+
+#Copyright of IBM
+#and Galasa
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -795,19 +917,19 @@ func TestReplaceCopyrightBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestReplaceCopyrightCommentBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- #Copyright of IBM
- #and Galasa
- apiVersion: apps/v1`
+#Copyright of IBM
+#and Galasa
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -818,21 +940,21 @@ func TestReplaceCopyrightCommentBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestReplaceCopyrightWithMultipleNewLinesBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash 
- 
- 
- #Copyright of IBM
- #and Galasa
- apiVersion: apps/v1`
+
+
+#Copyright of IBM
+#and Galasa
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -843,20 +965,20 @@ func TestReplaceCopyrightWithMultipleNewLinesBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestReplaceCopyrightWithLeadingHashBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- #
- #Copyright of IBM
- #and Galasa
- apiVersion: apps/v1`
+#
+#Copyright of IBM
+#and Galasa
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -867,20 +989,20 @@ func TestReplaceCopyrightWithLeadingHashBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestCommentDoesNotContainCopyrightAndHasLeadingTextBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- 
- hello world!
- #what copyright info is this?
- apiVersion: apps/v1`
+
+hello world!
+#what copyright info is this?
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -891,10 +1013,10 @@ func TestCommentDoesNotContainCopyrightAndHasLeadingTextBashScript(t *testing.T)
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "#what copyright info is this?")
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
@@ -902,13 +1024,13 @@ func TestCommentDoesNotContainCopyrightAndHasLeadingTextBashScript(t *testing.T)
 func TestNoCopyrightChangeNeededBashScript(t *testing.T) {
 	// Given..
 	var input = `#!/usr/bin/env bash
- 
- #
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #
- apiVersion: apps/v1`
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")
@@ -919,19 +1041,19 @@ func TestNoCopyrightChangeNeededBashScript(t *testing.T) {
 		assert.Fail(t, "Bash Script must start with '#!/usr/bin/env bash'. output:\n%s", output)
 	}
 	assert.Contains(t, output, `#
- # Copyright contributors to the Galasa project
- #
- # SPDX-License-Identifier: EPL-2.0
- #`)
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#`)
 	assert.Contains(t, output, "apiVersion: apps/v1")
 }
 
 func TestCopyrightCommentIsNotToBeRemovedBashScript(t *testing.T) {
 	// Given..
 	var input = `#! /usr/bin/env bash
- # Copyright contributions of Shrek
- #
- apiVersion: apps/v1`
+# Copyright contributions of Shrek
+#
+apiVersion: apps/v1`
 
 	// When...
 	output, _ := setCopyright(input, "#")


### PR DESCRIPTION
Signed-off-by: Fiona Ampofo <64271621+Akyiaa@users.noreply.github.com>

removed whitespaces that were causing errors on local build
adding whitespaces for outputs to make them look cleaner and help with possible future re-applications of the copyrighter tool
more tests for double stroke comments
