### PR TITLE
mcobbett cli skips ecosystem tests

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -449,7 +449,8 @@ spec:
     taskRef: 
       name: docker-build
     runAfter:
-    - test-galasactl-ecosystem-linux-x86-64
+    # We are temporarily disabling the ecosystem tets. - test-galasactl-ecosystem-linux-x86-64
+    - test-galasactl-local-gradle-linux-x86-64
     params:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -464,7 +464,8 @@ spec:
     taskRef: 
       name: docker-build
     runAfter:
-    - test-galasactl-ecosystem-linux-x86-64
+    # We are temporarily disabling the ecosystem tets. - test-galasactl-ecosystem-linux-x86-64
+    - test-galasactl-local-gradle-linux-x86-64  
     params:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)


### PR DESCRIPTION
- CLI pipeline doesnt contact the prod ecosystem as it is sick. Temporary
- CLI pipeline doesnt contact the prod ecosystem as it is sick. Temporary
- CLI pipeline doesnt contact the prod ecosystem as it is sick. Temporary
