### PR TITLE
Service account for galasa build can now see the planb-harbor basic auth creds secret

### DIFF
--- a/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
+++ b/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
@@ -12,6 +12,7 @@ metadata:
 secrets:
 - name: harbor-creds
 - name: icr-api-key
+- name: planb-harbor-creds
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
