### PR TITLE
mcobbett branch maven repository adding app

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/argo-app-create.sh
+++ b/infrastructure/galasa-plan-b-lon02/argo-app-create.sh
@@ -65,6 +65,8 @@ function create_application {
     app_name=$1
     repo_path=$2
 
+    h2 "Creating argocd application ${app_name}"
+
     argocd app create ${app_name} \
     --repo https://github.com/galasa-dev/automation.git \
     --path ${base_git_repo_path}/${repo_path} \
@@ -73,6 +75,11 @@ function create_application {
     --dest-namespace galasa-development \
     --project default 
     rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to create application ${app_name}. rc=${rc}" ; exit 1 ; fi
+
+    cmd="argocd app sync ${app_name}"
+    info "Command to run is $cmd"
+    $cmd
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to sync application ${app_name}. rc=${rc}" ; exit 1 ; fi
 }
 
 function create_helm_application {
@@ -100,6 +107,11 @@ function create_helm_application {
     info "Command to run is $cmd"
     $cmd
     rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to set values into application ${app_name}. rc=${rc}" ; exit 1 ; fi
+
+    cmd="argocd app sync ${app_name}"
+    info "Command to run is $cmd"
+    $cmd
+    rc=$? ; if [[ "${rc}" != "0" ]]; then error "Failed to sync application ${app_name}. rc=${rc}" ; exit 1 ; fi
 }
 
 function delete_application {
@@ -114,13 +126,15 @@ function delete_application {
 }
 
 # delete_application "codecov-maven-repos"
-
 # create_helm_application "codecov-maven-repos" \
 # "galasa-development/branch-maven-repository" \
 # "values-used-by-different-argo-apps/codecov-maven-repos.yaml"
 
+# delete_application "github-copyright"
 # create_application "github-copyright" "galasa-development/github-copyright"
-# create_application "github-webhook_receiver" "galasa-development/github-copyright"
+
+# delete_application "github-webhook-receiver"
+# create_application "github-webhook-receiver" "galasa-development/github-webhook-receiver"
 
 # delete_application "integration-maven-repos"
 # create_helm_application "integration-maven-repos" \
@@ -132,10 +146,18 @@ function delete_application {
 # "galasa-development/branch-maven-repository" \
 # "values-used-by-different-argo-apps/main-maven-repos.yaml"
 
+# delete_application "prod-maven-repos"
+# create_helm_application "prod-maven-repos" \
+# "galasa-development/branch-maven-repository" \
+# "values-used-by-different-argo-apps/prod-maven-repos.yaml"
 
-delete_application "prod-maven-repos"
-create_helm_application "prod-maven-repos" \
-"galasa-development/branch-maven-repository" \
-"values-used-by-different-argo-apps/prod-maven-repos.yaml"
+delete_application "main-bld"
+create_application "main-bld" "galasa-development/galasabld" 
+
+delete_application "main-inttests"
+create_application "main-inttests" "galasa-development/inttests" 
+
+delete_application "main-simplatform"
+create_application "main-simplatform" "galasa-development/simplatform"
 
 

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/Chart.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/Chart.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: galasabld
+description: Configuration for galasabld binary downloadable site
+type: application
+version: 0.1.0
+appVersion: "0.20.0"

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/deployment.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bld-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  revisionHistoryLimit: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bld-{{ .Values.branch }}
+  template:
+    metadata:
+      name: bld-{{ .Values.branch }}
+      labels:
+        app: bld-{{ .Values.branch }}
+    spec:
+      containers:
+        - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: Always
+          name: bld-{{ .Values.branch }}
+          env:
+          - name: CONTEXTROOT
+            value: {{ .Values.branch }}/binary/bld
+          ports:
+          - containerPort: 80

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/ingress.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bld-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "public-iks-k8s-nginx"
+spec:
+  tls:
+  - hosts:
+    - development.galasa.dev
+    secretName: galasa-wildcard-cert
+  rules:
+  - host: development.galasa.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: bld-{{ .Values.branch }}
+            port:
+              number: 80
+        path: /{{ .Values.branch}}/binary/bld
+        pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/service.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/service.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: bld-{{ .Values.branch }}
+  name: bld-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: bld-{{ .Values.branch }}

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: main
+imageName: harbor.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud/galasadev/galasabld-binary-downloadables
+imageTag: main

--- a/infrastructure/galasa-plan-b-lon02/inttests/Chart.yaml
+++ b/infrastructure/galasa-plan-b-lon02/inttests/Chart.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: galasa-repositories
+description: The repositories for a Galasa build
+type: application
+version: 0.1.0
+appVersion: "0.20.0"

--- a/infrastructure/galasa-plan-b-lon02/inttests/templates/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/inttests/templates/deployment.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inttests-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: inttests-{{ .Values.branch }}
+  template:
+    metadata:
+      name: inttests-{{ .Values.branch }}
+      labels:
+        app: inttests-{{ .Values.branch }}
+    spec:
+      containers:
+        - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: Always
+          name: inttests-{{ .Values.branch }}
+          env:
+          - name: CONTEXTROOT
+            value: {{ .Values.branch }}/maven-repo/inttests
+          ports:
+            - containerPort: 80

--- a/infrastructure/galasa-plan-b-lon02/inttests/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/inttests/templates/ingress.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: inttests-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "public-iks-k8s-nginx"
+    
+spec:
+  tls:
+  - hosts:
+    - development.galasa.dev
+    secretName: galasa-wildcard-cert
+  rules:
+  - host: development.galasa.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: inttests-{{ .Values.branch }}
+            port:
+              number: 80
+        path: /{{ .Values.branch }}/maven-repo/inttests
+        pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/inttests/templates/service.yaml
+++ b/infrastructure/galasa-plan-b-lon02/inttests/templates/service.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: inttests-{{ .Values.branch }}
+  name: inttests-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: inttests-{{ .Values.branch }}

--- a/infrastructure/galasa-plan-b-lon02/inttests/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/inttests/values.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: main
+imageName: harbor.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud/galasadev/galasa-inttests
+imageTag: main

--- a/infrastructure/galasa-plan-b-lon02/simplatform/Chart.yaml
+++ b/infrastructure/galasa-plan-b-lon02/simplatform/Chart.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: galasa-repositories
+description: The repositories for a Galasa build
+type: application
+version: 0.1.0
+appVersion: "0.20.0"

--- a/infrastructure/galasa-plan-b-lon02/simplatform/templates/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/simplatform/templates/deployment.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplatform-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: simplatform-{{ .Values.branch }}
+  template:
+    metadata:
+      name: simplatform-{{ .Values.branch }}
+      labels:
+        app: simplatform-{{ .Values.branch }}
+    spec:
+      containers:
+        - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: Always
+          name: simplatform-{{ .Values.branch }}
+          env:
+          - name: CONTEXTROOT
+            value: {{ .Values.branch }}/maven-repo/simplatform
+          ports:
+            - containerPort: 80

--- a/infrastructure/galasa-plan-b-lon02/simplatform/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/simplatform/templates/ingress.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: simplatform-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: "public-iks-k8s-nginx"
+    
+spec:
+  tls:
+  - hosts:
+    - development.galasa.dev
+    secretName: galasa-wildcard-cert
+  rules:
+  - host: development.galasa.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: simplatform-{{ .Values.branch }}
+            port:
+              number: 80
+        path: /{{ .Values.branch }}/maven-repo/simplatform
+        pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/simplatform/templates/service.yaml
+++ b/infrastructure/galasa-plan-b-lon02/simplatform/templates/service.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: simplatform-{{ .Values.branch }}
+  name: simplatform-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: simplatform-{{ .Values.branch }}

--- a/infrastructure/galasa-plan-b-lon02/simplatform/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/simplatform/values.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: main
+imageName: harbor.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud/galasadev/galasa-simplatform
+imageTag: main


### PR DESCRIPTION
- adding helm content for argocd application branch-maven-repository
- dont use development.galasa.dev in new cluster yet
- script for creating argocd applications
- argocd app create scripts for main-maven-repos and integration-maven-repos
- prod-maven-repos helm chart values uploaded for use
- added more argocd applications
