### PR TITLE
mcobbett branch maven repository adding app

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/argo-app-create.sh
+++ b/infrastructure/galasa-plan-b-lon02/argo-app-create.sh
@@ -146,18 +146,21 @@ function delete_application {
 # "galasa-development/branch-maven-repository" \
 # "values-used-by-different-argo-apps/main-maven-repos.yaml"
 
+
+
+# delete_application "main-bld"
+# create_application "main-bld" "galasa-development/galasabld" 
+
+# delete_application "main-inttests"
+# create_application "main-inttests" "galasa-development/inttests" 
+
+delete_application "main-simplatform"
+create_helm_application "main-simplatform" "galasa-development/simplatform" "values-used-by-different-argo-apps/main-simplatform-values.yaml"
+
+delete_application "prod-simplatform"
+create_helm_application "prod-simplatform" "galasa-development/simplatform" "values-used-by-different-argo-apps/prod-simplatform-values.yaml"
+
 # delete_application "prod-maven-repos"
 # create_helm_application "prod-maven-repos" \
 # "galasa-development/branch-maven-repository" \
 # "values-used-by-different-argo-apps/prod-maven-repos.yaml"
-
-delete_application "main-bld"
-create_application "main-bld" "galasa-development/galasabld" 
-
-delete_application "main-inttests"
-create_application "main-inttests" "galasa-development/inttests" 
-
-delete_application "main-simplatform"
-create_application "main-simplatform" "galasa-development/simplatform"
-
-

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/values-used-by-different-argo-apps/main-simplatform-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/values-used-by-different-argo-apps/main-simplatform-values.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: main
+imageName: harbor.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud/galasadev/galasa-simplatform
+imageTag: main

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/values-used-by-different-argo-apps/prod-simplatform-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/values-used-by-different-argo-apps/prod-simplatform-values.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: prod
+imageName: harbor.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud/galasadev/galasa-simplatform
+imageTag: prod


### PR DESCRIPTION
- adding helm content for argocd application branch-maven-repository
- dont use development.galasa.dev in new cluster yet
- script for creating argocd applications
- argocd app create scripts for main-maven-repos and integration-maven-repos
- prod-maven-repos helm chart values uploaded for use
- added more argocd applications
- added more argocd applications
- added more argocd applications
- added prod-simplatform application
