### PR TITLE
Build pipelines for GitHub copyright image - progress so far.

### DIFF
--- a/pipelines/pipelines/githubapp-copyright/build-branch.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-branch.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: branch-githubapp-copyright
+  namespace: galasa-build
+spec:
+
+  workspaces:
+  - name: git-workspace
+# 
+# 
+#
+  tasks:
+# 
+# 
+# 
+  - name: clone-githubapp-copyright
+    taskRef: 
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/githubapp-copyright
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    workspaces:
+     - name: output
+       workspace: git-workspace 
+#
+#
+#
+  - name: githubapp-copyright-make
+    taskRef: 
+      name: make
+    runAfter: 
+    - clone-githubapp-copyright
+    params:
+    - name: directory
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+# 
+# 
+#
+  - name: docker-build-githubapp-copyright
+    taskRef:
+      name: docker-build
+    runAfter:
+    - githubapp-copyright-make
+    params:
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: context
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    - name: dockerfilePath
+      value: githubapp-copyright/Dockerfile
+    - name: imageName
+      value: harbor.galasa.dev/galasadev/galasa-copyright:latest
+    - name: noPush
+      value: ""
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace

--- a/pipelines/pipelines/githubapp-copyright/build-pr.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-pr.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pr-githubapp-copyright
+  namespace: galasa-build
+spec:
+  params:
+  - name: headRef
+    type: string
+  - name: headSha
+    type: string
+  - name: baseRef
+    type: string
+  - name: prUrl
+    type: string
+  - name: statusesUrl
+    type: string
+  - name: issueUrl
+    type: string
+  - name: userId
+    type: string
+  - name: prNumber
+    type: string
+  - name: action
+    type: string
+  workspaces:
+  - name: git-workspace
+# 
+# 
+#
+  tasks:
+  - name: git-verify
+    taskRef:
+      name: git-verify
+    params:
+    - name: userId
+      value: $(params.userId)
+    - name: prUrl
+      value: $(params.prUrl)
+    - name: action
+      value: $(params.action)
+# 
+# 
+# 
+  - name: clone-githubapp-copyright
+    taskRef: 
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/githubapp-copyright
+    - name: revision
+      value: $(params.baseRef)
+    - name: refspec
+      value: refs/pull/$(params.prNumber)/head:refs/heads/$(params.baseRef)
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    workspaces:
+     - name: output
+       workspace: git-workspace 
+#
+#
+#
+  - name: githubapp-copyright-make
+    taskRef: 
+      name: make
+    runAfter: 
+    - clone-githubapp-copyright
+    params:
+    - name: directory
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+# 
+# 
+#
+  - name: docker-build-githubapp-copyright
+    taskRef:
+      name: docker-build
+    runAfter:
+    - githubapp-copyright-make
+    params:
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: context
+      value: $(context.pipelineRun.name)/githubapp-copyright
+    - name: dockerfilePath
+      value: githubapp-copyright/Dockerfile
+    - name: imageName
+      value: harbor.galasa.dev/galasadev/githubapp-copyright:$(params.headSha)
+    - name: noPush
+      value: ""
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+#
+#
+#
+  finally:
+
+  - name: ls
+    taskRef: 
+      name: script
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/githubapp-copyright/build
+    - name: script
+      value:  
+        ls
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
+  - name: git-status
+    when:
+      - input: "$(tasks.git-verify.status)"
+        operator: in
+        values: ["Succeeded"]
+    taskRef:
+      name: git-status
+    params:
+    - name: status
+      value: $(tasks.status)
+    - name: prUrl
+      value: $(params.prUrl)
+    - name: statusesUrl
+      value: $(params.statusesUrl)
+    - name: issueUrl
+      value: $(params.issueUrl)
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name) 

--- a/pipelines/pipelines/githubapp-copyright/build-pr.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-pr.yaml
@@ -106,19 +106,6 @@ spec:
 #
   finally:
 
-  - name: ls
-    taskRef: 
-      name: script
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/githubapp-copyright/build
-    - name: script
-      value:  
-        ls
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-
   - name: git-status
     when:
       - input: "$(tasks.git-verify.status)"

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -40,7 +40,9 @@ spec:
     image: docker.io/library/busybox:latest
     imagePullPolicy: Always
     command:
-    - cp /workspace/git/$(params.directory)/key/key.pem /workspace/git/$(params.directory)/build
+    - cp
+    - /workspace/git/$(params.directory)/key/key.pem
+    - /workspace/git/$(params.directory)/build
   - name: list-build-dir-contents-2
     workingDir: /workspace/git/$(params.directory)/build
     image: docker.io/library/busybox:latest
@@ -55,9 +57,12 @@ spec:
     - make
     - all
     volumeMounts: 
+    # Where we are getting the key.pem from a secret
+    # It will be copied into a different directory as volumeMounts from secrets are read only
     - name: githubapp-copyright-unit-test-key
       mountPath: /workspace/git/$(params.directory)/key
-      # mountPath: /workspace/git/$(params.directory)/build
+    # Where the key.pem will be copied to, emptyDirs are read and write
+    # Needs to be read and write as the Makefile will be making changes in here
     - name: build-directory 
       mountPath: /workspace/git/$(params.directory)/build
   volumes:

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -17,12 +17,14 @@ spec:
   - name: directory
     type: string  
   steps:
+  # Check the /build and /key directories are made by the volumeMounts below - WORKS
   - name: list-main-dir-contents
     workingDir: /workspace/git/$(params.directory)
     image: docker.io/library/busybox:latest
     imagePullPolicy: Always
     command:
     - ls
+  # Check the key.pem is inside /key - DOES NOT WORK
   - name: list-key-dir-contents
     workingDir: /workspace/git/$(params.directory)/key
     image: docker.io/library/busybox:latest
@@ -35,6 +37,7 @@ spec:
     imagePullPolicy: Always
     command:
     - ls
+  # Copy key.pem from /key which is read only to /build which the Makefile needs - DOES NOT WORK AS key.pem IS NOT IN /key
   - name: copy-key
     workingDir: /workspace/git/$(params.directory)
     image: docker.io/library/busybox:latest

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -40,7 +40,7 @@ spec:
     image: docker.io/library/busybox:latest
     imagePullPolicy: Always
     command:
-    - cp /workspace/git/$(params.directory)/key/* /workspace/git/$(params.directory)/build
+    - cp /workspace/git/$(params.directory)/key/key.pem /workspace/git/$(params.directory)/build
   - name: list-build-dir-contents-2
     workingDir: /workspace/git/$(params.directory)/build
     image: docker.io/library/busybox:latest

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -17,6 +17,36 @@ spec:
   - name: directory
     type: string  
   steps:
+  - name: list-main-dir-contents
+    workingDir: /workspace/git/$(params.directory)
+    image: docker.io/library/busybox:latest
+    imagePullPolicy: Always
+    command:
+    - ls
+  - name: list-key-dir-contents
+    workingDir: /workspace/git/$(params.directory)/key
+    image: docker.io/library/busybox:latest
+    imagePullPolicy: Always
+    command:
+    - ls
+  - name: list-build-dir-contents-1
+    workingDir: /workspace/git/$(params.directory)/build
+    image: docker.io/library/busybox:latest
+    imagePullPolicy: Always
+    command:
+    - ls
+  - name: copy-key
+    workingDir: /workspace/git/$(params.directory)
+    image: docker.io/library/busybox:latest
+    imagePullPolicy: Always
+    command:
+    - cp /workspace/git/$(params.directory)/key/* /workspace/git/$(params.directory)/build
+  - name: list-build-dir-contents-2
+    workingDir: /workspace/git/$(params.directory)/build
+    image: docker.io/library/busybox:latest
+    imagePullPolicy: Always
+    command:
+    - ls
   - name: make
     workingDir: /workspace/git/$(params.directory)
     image: docker.io/library/golang:latest
@@ -26,8 +56,13 @@ spec:
     - all
     volumeMounts: 
     - name: githubapp-copyright-unit-test-key
-      mountPath: /key
+      mountPath: /workspace/git/$(params.directory)/key
+      # mountPath: /workspace/git/$(params.directory)/build
+    - name: build-directory 
+      mountPath: /workspace/git/$(params.directory)/build
   volumes:
     - name: githubapp-copyright-unit-test-key
       secret:
         secretName: githubapp-copyright-unit-test-key
+    - name: build-directory
+      emptyDir: {}


### PR DESCRIPTION
Do not merge! This does not work yet.

The pipelines shouldn't need any further edits, but the 'make' Task is where I am having issues getting the key.pem needed to mount correctly. key.pem is contained in the Secret 'githubapp-copyright-unit-test-keys' which is merged into main branch already.

I have tried to mount the key.pem into the /key directory, then copy key.pem into the /build directory where it is needed by the Makefile. It can't be mounted initially into the /build directory as directories from secrets are set to read-only, and the Makefile needs to be able to write to /build. But, the key.pem isn't even being put into the /key directory, so the copy is of course failing. Unsure where to go next or what's going wrong..

I am trying to do the exact same thing as this Task https://github.com/galasa-dev/automation/blob/main/releasePipeline/argocd-synced/tasks/deploy-maven-galasa.yaml with this Secret: https://github.com/galasa-dev/automation/blob/main/infrastructure/cicsk8s/galasa-build/external-secrets/secret-maven-creds.yaml but it does not seem to be working for me.