### PR TITLE
mcobbett mount githubapp key

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         - command:
             - copyright
           image: 'harbor.galasa.dev/galasadev/galasa-copyright:latest'
+          imagePullPolicy: Always
           name: copyright
           ports:
             - containerPort: 3000

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/secret-github-app-copyright.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/secret-github-app-copyright.yaml
@@ -19,7 +19,7 @@ spec:
       type: Opaque
 
   data:
-  - secretKey: github-copyright-app-key
+  - secretKey: key.pem
     # Corresponds to the secret: 'planb-galasa-github-copyright-app'
     remoteRef:
       key: arbitrary/4979621c-d47f-27d0-6d78-72a8298d99d1


### PR DESCRIPTION
- Mount the key.pem for copyright app in the correct place. Attempt 1.
- rename copyryright app secret key resource
