### PR TITLE
mcobbett mount githubapp key

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
@@ -36,3 +36,7 @@ spec:
         - name: key
           secret:
             secretName: github-copyright-app-key
+            items:
+              - key: key.pem
+                path: key.pem
+            defaultMode: 440


### PR DESCRIPTION
- Mount the key.pem for copyright app in the correct place. Attempt 1.
- rename copyryright app secret key resource
- rename copyryright app secret key resource
