### PR TITLE
mcobbett fix copyright checker build

### DIFF
--- a/pipelines/pipelines/githubapp-copyright/build-pr.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-pr.yaml
@@ -31,7 +31,7 @@ spec:
     type: string
   workspaces:
   - name: git-workspace
-  - name: keys-workspace
+
 # 
 # 
 #


### PR DESCRIPTION
- copyright pipeline make - parameters not expanding correctly.
- copyright pipeline make - parameters not expanding correctly.
- keys workspace is not needed for copyright app build pipeline
