### PR TITLE
copyright checker app deployment gets kicked once new image is available.

### DIFF
--- a/pipelines/pipelines/githubapp-copyright/build-branch.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-branch.yaml
@@ -93,12 +93,12 @@ spec:
       - app 
       - actions 
       - run 
-      - $(params.appnameCli)
+      - github-copyright
       - restart 
       - --kind 
       - Deployment
       - --resource-name
-      - cli-$(params.imageTag)
+      - githubappcopyright
 
   #----------------------------------------------------------------
   - name: wait-cli-binary
@@ -113,7 +113,7 @@ spec:
       value: 
       - app 
       - wait
-      - $(params.appnameCli)
+      - github-copyright
       - --resource
       - apps:Deployment:githubappcopyright
       - --health    

--- a/pipelines/pipelines/githubapp-copyright/build-branch.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-branch.yaml
@@ -17,9 +17,10 @@ spec:
 # 
 #
   tasks:
-# 
-# 
-# 
+
+  # 
+  # Clone the github depo.
+  # 
   - name: clone-githubapp-copyright
     taskRef: 
       name: git-clone
@@ -37,9 +38,10 @@ spec:
     workspaces:
      - name: output
        workspace: git-workspace 
-#
-#
-#
+
+  #
+  # Build the copyright checker source code.
+  #
   - name: githubapp-copyright-make
     taskRef: 
       name: make
@@ -51,9 +53,10 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
-# 
-# 
-#
+
+  # 
+  # Assemble into a container image.
+  #
   - name: docker-build-githubapp-copyright
     taskRef:
       name: docker-build
@@ -73,3 +76,45 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
+
+  # 
+  # Assemble into a container image.
+  #
+  - name: recycle-deployment
+    taskRef:
+      name: argocd-cli
+    runAfter:
+    - docker-build-githubapp-copyright
+    params:
+    - name: server
+      value: argocd.galasa.dev
+    - name: command
+      value: 
+      - app 
+      - actions 
+      - run 
+      - $(params.appnameCli)
+      - restart 
+      - --kind 
+      - Deployment
+      - --resource-name
+      - cli-$(params.imageTag)
+
+  #----------------------------------------------------------------
+  - name: wait-cli-binary
+    taskRef:
+      name: argocd-cli
+    runAfter:
+    - recycle-cli-binary
+    params:
+    - name: server
+      value: argocd.galasa.dev
+    - name: command
+      value: 
+      - app 
+      - wait
+      - $(params.appnameCli)
+      - --resource
+      - apps:Deployment:githubappcopyright
+      - --health    
+     


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Once the new container image is built and pushed to harbor, the argocd copyright checker app needs to be recycled.
