### PR TITLE
mcobbett nexus adding back in

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/nexus/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/nexus/deployment.yaml
@@ -29,9 +29,6 @@ spec:
       - name: nexus
         image: sonatype/nexus3:3.29.0
 #        imagePullPolicy: Always
-        env:
-        - name: NEXUS_CONTEXT
-          value: nexus
         ports:
         - containerPort: 8081
           name: http


### PR DESCRIPTION
- Adding nexus into ingress on galasa-production
- nexus namespace added
- add targetports to service to get nexus traffic routed through
- upgrade nexus to 3:3.29 from 3:3.23
- forget setting the nexus context so we can use nexus.galasa.dev/ only as a URL
