### PR TITLE
mcobbett nexus adding back in

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/nexus/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/nexus/ingress.yaml
@@ -14,11 +14,11 @@ metadata:
 spec:
   tls:
   - hosts:
-    - nexus-planb.galasa.dev
+    - nexus.galasa.dev
     - docker.galasa.dev
     secretName: galasa-wildcard-cert
   rules:
-  - host: nexus-planb.galasa.dev
+  - host: nexus.galasa.dev
     http:
       paths:
       - backend:


### PR DESCRIPTION
- Adding nexus into ingress on galasa-production
- nexus namespace added
- add targetports to service to get nexus traffic routed through
- upgrade nexus to 3:3.29 from 3:3.23
- forget setting the nexus context so we can use nexus.galasa.dev/ only as a URL
- routing nexus.galasa.dev to the new cluster
