### PR TITLE
mcobbett nexus adding back in

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/nexus/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/nexus/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           mountPath: /nexus-data
         resources:
           requests:
-            cpu: "2"
+            cpu: "4"
       volumes:
       - name: datadir
         persistentVolumeClaim:


### PR DESCRIPTION
- Adding nexus into ingress on galasa-production
- nexus namespace added
- add targetports to service to get nexus traffic routed through
- upgrade nexus to 3:3.29 from 3:3.23
- forget setting the nexus context so we can use nexus.galasa.dev/ only as a URL
- routing nexus.galasa.dev to the new cluster
- nexus wants 4 cpus
