### PR TITLE
mcobbett nexus adding back in

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           image: 'harbor.galasa.dev/galasadev/galasa-copyright:latest'
           imagePullPolicy: Always
           name: copyright
-          args: ["/secrets/key.pem"]
+          args: ["--githubAuthKeyFile","/secrets/key.pem","--debug"]
           ports:
             - containerPort: 3000
           volumeMounts:


### PR DESCRIPTION
- Adding nexus into ingress on galasa-production
- nexus namespace added
- add targetports to service to get nexus traffic routed through
- upgrade nexus to 3:3.29 from 3:3.23
- forget setting the nexus context so we can use nexus.galasa.dev/ only as a URL
- routing nexus.galasa.dev to the new cluster
- nexus wants 4 cpus
- copyright app needs new command-line parameters
