### PR TITLE
mcobbett nexus adding back in

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-deployment.yaml
@@ -31,13 +31,12 @@ spec:
           volumeMounts:
             - mountPath: /secrets
               subPath: key.pem 
-              name: key
-              readOnly: true
+              name: secrets-volume
       volumes:
-        - name: key
+        - name: secrets-volume
           secret:
             secretName: github-copyright-app-key
             items:
               - key: key.pem
                 path: key.pem
-            defaultMode: 440
+            defaultMode: 444


### PR DESCRIPTION
- Adding nexus into ingress on galasa-production
- nexus namespace added
- add targetports to service to get nexus traffic routed through
- upgrade nexus to 3:3.29 from 3:3.23
- forget setting the nexus context so we can use nexus.galasa.dev/ only as a URL
- routing nexus.galasa.dev to the new cluster
- nexus wants 4 cpus
- copyright app needs new command-line parameters
- secret not mounting properly for copyright checker
