### PR TITLE
mcobbett copyright listens on port 3000

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-ingress.yaml
@@ -26,6 +26,6 @@ spec:
           service:
             name: githubappcopyright
             port:
-              number: 3000
+              number: 80
         path: /
         pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-service.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-service.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: galasa-development
 spec:
   ports:
-    - port: 3000
+    - port: 80
       protocol: TCP
   selector:
     app: githubappcopyright


### PR DESCRIPTION
- force a build
- force a build
- copyright checker should be on port 3000
- copyright checker should be on port 3000
- Use port 80 for copyright tool.
