### PR TITLE
Copyright handler set ingress path to match the webhook

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-copyright/github-app-copyright-ingress.yaml
@@ -27,5 +27,5 @@ spec:
             name: githubappcopyright
             port:
               number: 443
-        path: /
+        path: /githubapp/copyright/event_handler
         pathType: Prefix


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>
