### PR TITLE
upgrade to latest alpine docker image

### DIFF
--- a/dockerfiles/cli/cli-dockerfile
+++ b/dockerfiles/cli/cli-dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 
 ARG platform
 

--- a/dockerfiles/common/argocd-dockerfile
+++ b/dockerfiles/common/argocd-dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 
 RUN apk --no-cache add curl
 

--- a/dockerfiles/common/ghstatus-dockerfile
+++ b/dockerfiles/common/ghstatus-dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 COPY bin/ghstatus /go/bin/ghstatus
 ENTRYPOINT ["/go/bin/ghstatus"]

--- a/dockerfiles/common/ghverify-dockerfile
+++ b/dockerfiles/common/ghverify-dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 COPY bin/ghverify /go/bin/ghverify
 ENTRYPOINT ["/go/bin/ghverify"]

--- a/dockerfiles/common/github-monitor-dockerfile
+++ b/dockerfiles/common/github-monitor-dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 COPY bin/ghmonitor /go/bin/ghmonitor
 ENTRYPOINT ["/go/bin/ghmonitor"]

--- a/dockerfiles/common/github-receiver-dockerfile
+++ b/dockerfiles/common/github-receiver-dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 COPY bin/ghreceiver /go/bin/ghreceiver
 ENTRYPOINT ["/go/bin/ghreceiver"]

--- a/dockerfiles/common/kubectl-dockerfile
+++ b/dockerfiles/common/kubectl-dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 
 RUN apk add curl
 

--- a/dockerfiles/common/tkn-dockerfile
+++ b/dockerfiles/common/tkn-dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1 
+FROM alpine:3.18.4
 
 RUN apk add curl
 RUN apk add sudo

--- a/dockerfiles/galasabld/galasabld-dockerfile
+++ b/dockerfiles/galasabld/galasabld-dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.1
+FROM alpine:3.18.4
 
 ARG platform
 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Trying to address [17 vulnerabilities in the CLI container image on IBM container registry#1628](https://github.com/galasa-dev/projectmanagement/issues/1628)

- Upgrading alpine base image.
- Not sure this will fix the vulnerabilities but worth a try to start with.
- Upgraded all the container images to use alpine 3.18.4

