### PR TITLE
Rename params in Tasks so params from the Pipeline dont trickle through 

### DIFF
--- a/pipelines/tasks/galasabld-command.yaml
+++ b/pipelines/tasks/galasabld-command.yaml
@@ -18,13 +18,13 @@ spec:
     type: string
   - name: command
     type: array
-  - name: imageTag
+  - name: galasabldImageTag
     type: string
     default: main
   steps:
   - name: galasabld
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/galasadev/galasabld:$(params.imageTag)
+    image: harbor.galasa.dev/galasadev/galasabld:$(params.galasabldImageTag)
     imagePullPolicy: Always
     command:
     - galasabld

--- a/pipelines/tasks/galasactl-command.yaml
+++ b/pipelines/tasks/galasactl-command.yaml
@@ -18,13 +18,13 @@ spec:
     type: string
   - name: command
     type: array
-  - name: tag
+  - name: galasactlImageTag
     type: string
     default: main
   steps:
   - name: galasactl
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:$(params.tag)
+    image: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:$(params.galasactlImageTag)
     imagePullPolicy: Always
     command:
     - galasactl

--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -22,7 +22,7 @@ spec:
     type: string  
     default: docker.io/library/busybox:latest
   steps:
-  - name: command
+  - name: run-command
     workingDir: /workspace/git/$(params.context)
     image: $(params.image)
     imagePullPolicy: Always


### PR DESCRIPTION
general-command also complaining as the step was the same name as a param.

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>