### PR TITLE
Use common httpd.conf file for docker images

### DIFF
--- a/dockerfiles/eclipse/eclipse-p2-dockerfile
+++ b/dockerfiles/eclipse/eclipse-p2-dockerfile
@@ -1,5 +1,6 @@
 FROM docker.io/library/httpd:2.4
 
 RUN rm -v /usr/local/apache2/htdocs/*
-COPY httpd.conf /usr/local/apache2/conf/httpd.conf
-COPY target/repository/ /usr/local/apache2/htdocs/
+COPY automation/dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+COPY eclipse/galasa-eclipse-parent/dev.galasa.eclipse.site/target/repository/ /usr/local/apache2/htdocs/

--- a/dockerfiles/galasabld/galasabld-binary-dockerfile
+++ b/dockerfiles/galasabld/galasabld-binary-dockerfile
@@ -1,10 +1,6 @@
 FROM docker.io/library/httpd:2.4
 
-ARG branch
-
 RUN rm -v /usr/local/apache2/htdocs/*
-COPY httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY automation/dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
 
-RUN sed -i "s/--branchname--/${branch}/"    /usr/local/apache2/conf/httpd.conf
-
-COPY bin/ /usr/local/apache2/htdocs/
+COPY buildutils/bin/ /usr/local/apache2/htdocs/

--- a/dockerfiles/httpdconf/httpd.conf
+++ b/dockerfiles/httpdconf/httpd.conf
@@ -262,7 +262,7 @@ ServerAdmin you@example.com
 # documents. By default, all requests are taken from this directory, but
 # symbolic links and aliases may be used to point to other locations.
 #
-Alias "/--branchname--/binary/bld" "/usr/local/apache2/htdocs"
+Alias "/${CONTEXTROOT}" "/usr/local/apache2/htdocs"
 
 DocumentRoot "/usr/local/apache2/htdocs"
 <Directory "/usr/local/apache2/htdocs">
@@ -279,7 +279,7 @@ DocumentRoot "/usr/local/apache2/htdocs"
     # for more information.
     #
     Options Indexes FollowSymLinks
-    IndexOptions FancyIndexing NameWidth=* SuppressDescription VersionSort
+    IndexOptions FancyIndexing
 
     #
     # AllowOverride controls what directives may be placed in .htaccess files.

--- a/dockerfiles/isolated/isolated-dockerfile
+++ b/dockerfiles/isolated/isolated-dockerfile
@@ -1,6 +1,8 @@
 FROM docker.io/library/httpd:2.4
 
-RUN rm -v /usr/local/apache2/htdocs/*
-COPY httpd.conf /usr/local/apache2/conf/httpd.conf
+ARG directory
 
-COPY target/isolated/ /usr/local/apache2/htdocs/
+RUN rm -v /usr/local/apache2/htdocs/*
+COPY automation/dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
+
+COPY ${directory}/target/isolated/ /usr/local/apache2/htdocs/

--- a/dockerfiles/javadoc/javadoc-site-dockerfile
+++ b/dockerfiles/javadoc/javadoc-site-dockerfile
@@ -1,9 +1,6 @@
 FROM docker.io/library/httpd:2.4
 
-ARG branch
-
 RUN rm -v /usr/local/apache2/htdocs/*
+COPY automation/dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
 
-COPY httpd.conf /usr/local/apache2/conf/httpd.conf
-
-COPY target/site/apidocs/ /usr/local/apache2/htdocs/
+COPY obr/javadocs/target/site/apidocs/ /usr/local/apache2/htdocs/

--- a/dockerfiles/restapidoc/restapidoc-site-dockerfile
+++ b/dockerfiles/restapidoc/restapidoc-site-dockerfile
@@ -2,6 +2,6 @@ FROM docker.io/library/httpd:2.4
 
 RUN rm -v /usr/local/apache2/htdocs/*
 
-COPY httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY automation/dockerfiles/httpdconf/httpd.conf /usr/local/apache2/conf/httpd.conf
 
-COPY docs/generated/galasaapi/ /usr/local/apache2/htdocs/
+COPY framework/docs/generated/galasaapi/ /usr/local/apache2/htdocs/

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -93,7 +93,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/buildutils
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/galasabld/galasabld-binary-dockerfile
     - name: imageName

--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -195,7 +195,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/eclipse/galasa-eclipse-parent/dev.galasa.eclipse.site
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/eclipse/eclipse-p2-dockerfile
     - name: imageName

--- a/pipelines/pipelines/eclipse/build-pr.yaml
+++ b/pipelines/pipelines/eclipse/build-pr.yaml
@@ -166,7 +166,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/eclipse/galasa-eclipse-parent/dev.galasa.eclipse.site
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/eclipse/eclipse-p2-dockerfile
     - name: imageName

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -208,7 +208,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasa-restapidoc-site:$(params.imageTag)
     - name: context
-      value: $(context.pipelineRun.name)/framework
+      value: $(context.pipelineRun.name)
     - name: noPush
       value: ""
     - name: dockerfilePath

--- a/pipelines/pipelines/framework/build-pr.yaml
+++ b/pipelines/pipelines/framework/build-pr.yaml
@@ -201,7 +201,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasa-restapidoc-site:$(params.headSha)
     - name: context
-      value: $(context.pipelineRun.name)/framework
+      value: $(context.pipelineRun.name)
     - name: noPush
       value: ""
     - name: dockerfilePath

--- a/pipelines/pipelines/isolated/build-branch.yaml
+++ b/pipelines/pipelines/isolated/build-branch.yaml
@@ -583,13 +583,16 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/full
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
       value: icr.io/galasadev/galasa-isolated:$(params.imageTag)
     - name: noPush
       value: ""
+    - name: buildArgs
+      value:
+        - "--build-arg=directory=isolated/full"
     workspaces:
       - name: git-workspace
         workspace: git-workspace  
@@ -605,7 +608,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/full
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
@@ -616,6 +619,7 @@ spec:
       value:
         - "--tarPath"
         - "/workspace/git/$(context.pipelineRun.name)/isolated/full/target/isolated/isolated.tar"
+        - "--build-arg=directory=isolated/full"
     workspaces:
       - name: git-workspace
         workspace: git-workspace       
@@ -678,7 +682,7 @@ spec:
     - name: buildArgs
       value:
         - "--build-arg=baseVersion=latest"
-        - "--build-arg=dockerRepository=harbor.galasa.dev"  
+        - "--build-arg=dockerRepository=harbor.galasa.dev"
     workspaces:
       - name: git-workspace
         workspace: git-workspace        
@@ -1137,13 +1141,16 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/mvp
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
       value: icr.io/galasadev/galasa-mvp:$(params.imageTag)
     - name: noPush
       value: ""
+    - name: buildArgs
+      value:
+        - "--build-arg=directory=isolated/mvp"
     workspaces:
       - name: git-workspace
         workspace: git-workspace  
@@ -1159,7 +1166,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/mvp
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
@@ -1170,6 +1177,7 @@ spec:
       value:
         - "--tarPath"
         - "/workspace/git/$(context.pipelineRun.name)/isolated/mvp/target/isolated/isolated.tar"
+        - "--build-arg=directory=isolated/mvp"
     workspaces:
       - name: git-workspace
         workspace: git-workspace       

--- a/pipelines/pipelines/isolated/build-pr.yaml
+++ b/pipelines/pipelines/isolated/build-pr.yaml
@@ -572,13 +572,16 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/full
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
       value: icr.io/galasadev/galasa-isolated:$(params.headSha)
     - name: noPush
       value: "--no-push"
+    - name: buildArgs
+      value:
+        - "--build-arg=directory=isolated/full"
     workspaces:
       - name: git-workspace
         workspace: git-workspace  
@@ -592,7 +595,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/full
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
@@ -603,6 +606,7 @@ spec:
       value:
         - "--tarPath"
         - "/workspace/git/$(context.pipelineRun.name)/isolated/full/target/isolated/isolated.tar"
+        - "--build-arg=directory=isolated/full"
     workspaces:
       - name: git-workspace
         workspace: git-workspace       
@@ -1069,13 +1073,16 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/mvp
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
       value: icr.io/galasadev/galasa-mvp:$(params.headSha)
     - name: noPush
       value: "--no-push"
+    - name: buildArgs
+      value:
+        - "--build-arg=directory=isolated/mvp"
     workspaces:
       - name: git-workspace
         workspace: git-workspace  
@@ -1089,7 +1096,7 @@ spec:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name)/isolated/mvp
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/isolated/isolated-dockerfile
     - name: imageName
@@ -1100,6 +1107,9 @@ spec:
       value:
         - "--tarPath"
         - "/workspace/git/$(context.pipelineRun.name)/isolated/mvp/target/isolated/isolated.tar"
+    - name: buildArgs
+      value:
+        - "--build-arg=directory=isolated/mvp"
     workspaces:
       - name: git-workspace
         workspace: git-workspace       

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -563,7 +563,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasa-javadoc-site:$(params.imageTag)
     - name: context
-      value: $(context.pipelineRun.name)/obr/javadocs
+      value: $(context.pipelineRun.name)
     - name: noPush
       value: ""
     - name: dockerfilePath

--- a/pipelines/pipelines/obr/build-pr.yaml
+++ b/pipelines/pipelines/obr/build-pr.yaml
@@ -381,7 +381,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasa-javadoc-site:$(params.headSha)
     - name: context
-      value: $(context.pipelineRun.name)/obr/javadocs
+      value: $(context.pipelineRun.name)
     - name: noPush
       value: ""
     - name: dockerfilePath


### PR DESCRIPTION
Use common httpd.conf file for eclipse-p2, galasabld-binary, isolated, javadoc-site and restapidoc-site images

Signed-off-by: Jade Carino <carino_jade@yahoo.co.uk>