### PR TITLE
Add galasa-ecosystem-admin Role, RoleBinding, and ServiceAccount for the galasa-ecosystem1 namespace

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
@@ -61,3 +61,17 @@ rules:
   - "externalsecrets"
   verbs:
   - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: galasa-ecosystem-admin
+  namespace: galasa-ecosystem1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: galasa-admin
+subjects:
+- kind: ServiceAccount
+  name: galasa-ecosystem1-admin

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: galasa-ecosystem-admin
+  namespace: galasa-ecosystem1
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - containers
+  - services
+  - configmaps
+  - persistentvolumeclaims
+  - secrets
+  - events
+  - serviceaccounts
+  - replicationcontrollers
+  - "pods/log"
+  - "pods/exec"
+  - "services/proxy"
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  - apps
+  - networking.k8s.io
+  - batch
+  - autoscaling
+  - rbac.authorization.k8s.io
+  resources:
+  - deployments
+  - "deployments/scale"
+  - daemonsets
+  - statefulsets
+  - replicasets
+  - ingresses
+  - cronjobs
+  - jobs
+  - horizontalpodautoscalers
+  - roles
+  - rolebindings
+  verbs:
+  - "*"
+- apiGroups:
+  - "tekton.dev"
+  - "triggers.tekton.dev"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - "external-secrets.io"
+  resources:
+  - "secretstores"
+  - "externalsecrets"
+  verbs:
+  - "*"

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-role.yaml
@@ -71,7 +71,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: galasa-admin
+  name: galasa-ecosystem-admin
 subjects:
 - kind: ServiceAccount
   name: galasa-ecosystem1-admin

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-service-account.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/admin-service-account.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: galasa-ecosystem1-admin
+  namespace: galasa-ecosystem1


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1341

- Defines the following for the plan B cluster's galasa-ecosystem1 namespace:
  - a `galasa-ecosystem-admin` Role
  - a `galasa-ecosystem-admin` RoleBinding
  - a `galasa-ecosystem1-admin` ServiceAccount 