### PR TITLE
Move webui dockerfile into automation repo and don't use multi-stage build

### DIFF
--- a/dockerfiles/webui/webui-dockerfile
+++ b/dockerfiles/webui/webui-dockerfile
@@ -1,0 +1,29 @@
+# Copies build artifacts from the webui build and runs the webui application.
+FROM node:18-alpine
+
+# Some libraries may apply production optimisations when NODE_ENV is set to "production"
+ENV NODE_ENV production
+
+# Our application sits in the the following folder...
+WORKDIR /galasa
+
+# Set up the application directory so that it is owned by the non-root node user
+RUN chown -R node:node /galasa
+
+# Take advantage of Next.js' automatic file tracing to reduce image size
+# See https://nextjs.org/docs/app/api-reference/next-config-js/output for information.
+COPY --chown=node:node .next/standalone ./
+COPY --chown=node:node .next/static ./.next/static
+COPY --chown=node:node ./public ./public
+
+# Never run anything in a docker container as the root user if you can help it.
+# Node images provide a non-root "node" user and group, so use that.
+USER node
+
+EXPOSE 8080
+ENV PORT 8080
+
+# Set hostname to localhost
+ENV HOSTNAME "0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/dockerfiles/webui/webui-dockerfile
+++ b/dockerfiles/webui/webui-dockerfile
@@ -1,5 +1,5 @@
 # Copies build artifacts from the webui build and runs the webui application.
-FROM node:18-alpine
+FROM node:20.10.0-alpine
 
 # Some libraries may apply production optimisations when NODE_ENV is set to "production"
 ENV NODE_ENV production

--- a/pipelines/pipelines/galasa-ui/build-branch.yaml
+++ b/pipelines/pipelines/galasa-ui/build-branch.yaml
@@ -24,11 +24,33 @@ spec:
     default: main
 
 #----------------------------------------------------------------
-# Clone the webui repository
+# Clone the automation repository
   tasks:
+  - name: clone-automation
+    taskRef: 
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/automation
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/automation
+    workspaces:
+     - name: output
+       workspace: git-workspace
+
+#----------------------------------------------------------------
+# Clone the webui repository
   - name: clone-webui
     taskRef:
       name: git-clone
+    runAfter:
+    - clone-automation
     params:
     - name: url
       value: https://github.com/galasa-dev/webui
@@ -64,14 +86,12 @@ spec:
 # Install the webui's dependencies
   - name: npm-install-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - check-branch
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -84,14 +104,12 @@ spec:
 # Generate gRPC types for the webui
   - name: generate-grpc-types
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - npm-install-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - ./node_modules/.bin/proto-loader-gen-types
@@ -107,14 +125,12 @@ spec:
 # Run the webui's unit tests
   - name: npm-test-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - generate-grpc-types
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -129,14 +145,12 @@ spec:
 # Build the webui
   - name: npm-build-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - npm-test-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -163,7 +177,7 @@ spec:
     - name: noPush
       value: ""
     - name: dockerfilePath
-      value: webui/galasa-ui/Dockerfile
+      value: automation/dockerfiles/webui/webui-dockerfile
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/pipelines/galasa-ui/build-pr.yaml
+++ b/pipelines/pipelines/galasa-ui/build-pr.yaml
@@ -49,12 +49,34 @@ spec:
       value: $(params.action)
 
 #----------------------------------------------------------------
+# Clone the automation repository
+  - name: clone-automation
+    taskRef: 
+      name: git-clone
+    runAfter:
+    - git-verify
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/automation
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/automation
+    workspaces:
+     - name: output
+       workspace: git-workspace
+
+#----------------------------------------------------------------
 # Clone the webui repository
   - name: clone-webui
     taskRef:
       name: git-clone
     runAfter:
-    - git-verify
+    - clone-automation
     params:
     - name: url
       value: https://github.com/galasa-dev/webui
@@ -74,14 +96,12 @@ spec:
 # Install the webui's dependencies
   - name: npm-install-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - clone-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -94,14 +114,12 @@ spec:
 # Generate gRPC types for the webui
   - name: generate-grpc-types
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - npm-install-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - ./node_modules/.bin/proto-loader-gen-types
@@ -117,14 +135,12 @@ spec:
 # Run the webui's unit tests
   - name: npm-test-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - generate-grpc-types
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -139,14 +155,12 @@ spec:
 # Build the webui
   - name: npm-build-webui
     taskRef:
-      name: general-command
+      name: nodejs
     runAfter:
     - npm-test-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: image
-      value: docker.io/library/node:18.16.0-alpine3.18
     - name: command
       value:
         - npm
@@ -173,7 +187,7 @@ spec:
     - name: noPush
       value: "--no-push"
     - name: dockerfilePath
-      value: webui/galasa-ui/Dockerfile
+      value: automation/dockerfiles/webui/webui-dockerfile
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/tasks/nodejs.yaml
+++ b/pipelines/tasks/nodejs.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: nodejs
+  namespace: galasa-build
+spec:
+  workspaces:
+  - name: git-workspace
+    mountPath: /workspace/git
+  params: 
+  - name: context
+    type: string
+  - name: command
+    type: array
+  steps:
+  - name: nodejs
+    workingDir: /workspace/git/$(params.context)
+    image: docker.io/library/node:20.10.0-alpine
+    imagePullPolicy: Always
+    command:
+      - $(params.command[*])


### PR DESCRIPTION
- Moved the webui Dockerfile into the automation repo to avoid having to make two PRs whenever the dockerfile and pipelines need changing.
- Removed the build stage from the Dockerfile due to infrastructure limitations and instead uses the built artifacts from the pipeline, like we do in the obr-generic pipeline.
- Added a nodejs task to avoid having to specify the node image every time we run an `npm` command in the pipelines