### PR TITLE
Galasabld task

### DIFF
--- a/pipelines/tasks/galasabld-command.yaml
+++ b/pipelines/tasks/galasabld-command.yaml
@@ -27,6 +27,7 @@ spec:
     image: harbor.galasa.dev/galasadev/galasabld-amd64:$(params.galasabldImageTag)
     imagePullPolicy: Always
     command:
+    - galasabld
     - $(params.command[*])
     volumeMounts:
     - name: githubcreds


### PR DESCRIPTION
I removed 'galasabld' the other day as as I believed the entrypoint for the image was already in /bin/galasabld but it appears I was mistaken.