### PR TITLE
Replace gRPC generation in webui pipelines with openapi client generation

### DIFF
--- a/dockerfiles/webui/webui-dockerfile
+++ b/dockerfiles/webui/webui-dockerfile
@@ -14,7 +14,6 @@ RUN chown -R node:node /galasa
 # See https://nextjs.org/docs/app/api-reference/next-config-js/output for information.
 COPY --chown=node:node .next/standalone ./
 COPY --chown=node:node .next/static ./.next/static
-COPY --chown=node:node ./public ./public
 
 # Never run anything in a docker container as the root user if you can help it.
 # Node images provide a non-root "node" user and group, so use that.

--- a/pipelines/pipelines/galasa-ui/build-branch.yaml
+++ b/pipelines/pipelines/galasa-ui/build-branch.yaml
@@ -82,32 +82,15 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
-#----------------------------------------------------------------
-# Install the webui's dependencies
-  - name: npm-install-webui
-    taskRef:
-      name: nodejs
-    runAfter:
-    - check-branch
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: command
-      value:
-        - npm
-        - install
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-
   #----------------------------------------------------------------
-  # Call gradle to pull-down dependencies we need and put them in
-  # the correct places.
-  - name: gather-dependencies
+  # Call gradle to pull-down dependencies we need and put them in the correct places,
+  # before generating the TypeScript client code from the openapi.yaml so the webui can
+  # talk to the API server.
+  - name: generate-api
     taskRef:
       name: gradle-build
     runAfter:
-    - npm-install-webui
+    - check-branch
     params:
     # The context indicates which folder the build.gradle is in.
     - name: context
@@ -119,42 +102,11 @@ spec:
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
     - name: command
       value:
-        - downloadDependencies
+        - generateTypeScriptClient
         - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace
-
-  #----------------------------------------------------------------
-  # Generate TypeScript client code from the openapi.yaml so the webui can
-  # talk to the API server.
-  - name: generate-api
-    taskRef:
-      name: general-command
-    runAfter:
-    - gather-dependencies
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/webui
-    - name: image
-      value: harbor.galasa.dev/common/openapi:main
-    - name: command
-      value:
-        - java
-        - -jar
-        - /opt/openapi/openapi-generator-cli.jar
-        - generate
-        - -i
-        - /workspace/git/$(context.pipelineRun.name)/webui/build/dependencies/openapi.yaml
-        - -g
-        - typescript
-        - -o
-        - galasa-ui/src/app/generated/galasaapi
-        - --additional-properties=packageName=galasaapi
-        - --global-property=apiTests=false
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
 
   #----------------------------------------------------------------
   # The generated TypeScript client code contains some compilation and build errors, which need fixing:
@@ -186,12 +138,30 @@ spec:
        workspace: git-workspace
 
 #----------------------------------------------------------------
+# Install the webui's dependencies
+  - name: npm-install-webui
+    taskRef:
+      name: nodejs
+    runAfter:
+    - fix-openapi-client
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui/galasa-ui
+    - name: command
+      value:
+        - npm
+        - install
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
+#----------------------------------------------------------------
 # Run the webui's unit tests
   - name: npm-test-webui
     taskRef:
       name: nodejs
     runAfter:
-    - fix-openapi-client
+    - npm-install-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui

--- a/pipelines/pipelines/galasa-ui/build-branch.yaml
+++ b/pipelines/pipelines/galasa-ui/build-branch.yaml
@@ -97,13 +97,10 @@ spec:
       value: $(context.pipelineRun.name)/webui
     - name: buildArgs
       value:
-        - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"
-        - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
-        - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
+        - "-PsourceMaven=https://development.galasa.dev/$(params.toBranch)/maven-repo/framework"
     - name: command
       value:
         - generateTypeScriptClient
-        - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace
@@ -125,7 +122,7 @@ spec:
     - name: script
       value:
         mkdir -p temp &&
-        promiseApiFile="galasa-ui/src/generated/galasaapi/PromiseAPI.ts" &&
+        promiseApiFile="galasa-ui/src/generated/galasaapi/types/PromiseAPI.ts" &&
         cat ${promiseApiFile} | sed "s/const result =/const apiResult =/g" > temp/PromiseAPI-temp.ts &&
         cat temp/PromiseAPI-temp.ts | sed "s/return result\.toPromise/return apiResult\.toPromise/g" > temp/PromiseAPI.ts &&
         cp temp/PromiseAPI.ts ${promiseApiFile} &&

--- a/pipelines/pipelines/galasa-ui/build-branch.yaml
+++ b/pipelines/pipelines/galasa-ui/build-branch.yaml
@@ -27,7 +27,7 @@ spec:
 # Clone the automation repository
   tasks:
   - name: clone-automation
-    taskRef: 
+    taskRef:
       name: git-clone
     params:
     - name: url
@@ -100,23 +100,87 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
-#----------------------------------------------------------------
-# Generate gRPC types for the webui
-  - name: generate-grpc-types
+  #----------------------------------------------------------------
+  # Call gradle to pull-down dependencies we need and put them in
+  # the correct places.
+  - name: gather-dependencies
     taskRef:
-      name: nodejs
+      name: gradle-build
     runAfter:
     - npm-install-webui
     params:
+    # The context indicates which folder the build.gradle is in.
     - name: context
-      value: $(context.pipelineRun.name)/webui/galasa-ui
+      value: $(context.pipelineRun.name)/webui
+    - name: buildArgs
+      value:
+        - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"
+        - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
+        - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
     - name: command
       value:
-        - ./node_modules/.bin/proto-loader-gen-types
-        - public/dex.proto
-        - -O
-        - src/generated/grpc
-        - --grpcLib=@grpc/grpc-js
+        - downloadDependencies
+        - --info
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace
+
+  #----------------------------------------------------------------
+  # Generate TypeScript client code from the openapi.yaml so the webui can
+  # talk to the API server.
+  - name: generate-api
+    taskRef:
+      name: general-command
+    runAfter:
+    - gather-dependencies
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui
+    - name: image
+      value: harbor.galasa.dev/common/openapi:main
+    - name: command
+      value:
+        - java
+        - -jar
+        - /opt/openapi/openapi-generator-cli.jar
+        - generate
+        - -i
+        - /workspace/git/$(context.pipelineRun.name)/webui/build/dependencies/openapi.yaml
+        - -g
+        - typescript
+        - -o
+        - galasa-ui/src/app/generated/galasaapi
+        - --additional-properties=packageName=galasaapi
+        - --global-property=apiTests=false
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
+  #----------------------------------------------------------------
+  # The generated TypeScript client code contains some compilation and build errors, which need fixing:
+  # 1. PromiseAPI.ts returns a constant named "result", which conflicts with the "result" field in a test run,
+  #    so rename the constant to something else.
+  # 2. index.ts runs into "Type error: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'",
+  #    so apply the suggested fix to the offending exports.
+  - name: fix-openapi-client
+    taskRef:
+      name: script
+    runAfter:
+    - generate-api
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui
+    - name: script
+      value:
+        mkdir -p temp &&
+        promiseApiFile="galasa-ui/src/generated/galasaapi/PromiseAPI.ts" &&
+        cat ${promiseApiFile} | sed "s/const result =/const apiResult =/g" > temp/PromiseAPI-temp.ts &&
+        cat temp/PromiseAPI-temp.ts | sed "s/return result\.toPromise/return apiResult\.toPromise/g" > temp/PromiseAPI.ts &&
+        cp temp/PromiseAPI.ts ${promiseApiFile} &&
+        indexFile="galasa-ui/src/generated/galasaapi/index.ts" &&
+        cat ${indexFile} | sed "s/export { Configuration/export { type Configuration/1" > temp/index-temp.ts &&
+        cat temp/index-temp.ts | sed "s/export { PromiseMiddleware/export { type PromiseMiddleware/1" > temp/index.ts &&
+        cp temp/index.ts ${indexFile}
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -127,7 +191,7 @@ spec:
     taskRef:
       name: nodejs
     runAfter:
-    - generate-grpc-types
+    - fix-openapi-client
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui

--- a/pipelines/pipelines/galasa-ui/build-pr.yaml
+++ b/pipelines/pipelines/galasa-ui/build-pr.yaml
@@ -51,7 +51,7 @@ spec:
 #----------------------------------------------------------------
 # Clone the automation repository
   - name: clone-automation
-    taskRef: 
+    taskRef:
       name: git-clone
     runAfter:
     - git-verify
@@ -110,23 +110,87 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
-#----------------------------------------------------------------
-# Generate gRPC types for the webui
-  - name: generate-grpc-types
+  #----------------------------------------------------------------
+  # Call gradle to pull-down dependencies we need and put them in
+  # the correct places.
+  - name: gather-dependencies
     taskRef:
-      name: nodejs
+      name: gradle-build
     runAfter:
     - npm-install-webui
     params:
+    # The context indicates which folder the build.gradle is in.
     - name: context
-      value: $(context.pipelineRun.name)/webui/galasa-ui
+      value: $(context.pipelineRun.name)/webui
+    - name: buildArgs
+      value:
+        - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"
+        - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
+        - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
     - name: command
       value:
-        - ./node_modules/.bin/proto-loader-gen-types
-        - public/dex.proto
-        - -O
-        - src/generated/grpc
-        - --grpcLib=@grpc/grpc-js
+        - downloadDependencies
+        - --info
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace
+
+  #----------------------------------------------------------------
+  # Generate TypeScript client code from the openapi.yaml so the webui can
+  # talk to the API server.
+  - name: generate-api
+    taskRef:
+      name: general-command
+    runAfter:
+    - gather-dependencies
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui
+    - name: image
+      value: harbor.galasa.dev/common/openapi:main
+    - name: command
+      value:
+        - java
+        - -jar
+        - /opt/openapi/openapi-generator-cli.jar
+        - generate
+        - -i
+        - /workspace/git/$(context.pipelineRun.name)/webui/build/dependencies/openapi.yaml
+        - -g
+        - typescript
+        - -o
+        - galasa-ui/src/app/generated/galasaapi
+        - --additional-properties=packageName=galasaapi
+        - --global-property=apiTests=false
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
+  #----------------------------------------------------------------
+  # The generated TypeScript client code contains some compilation and build errors, which need fixing:
+  # 1. PromiseAPI.ts returns a constant named "result", which conflicts with the "result" field in a test run,
+  #    so rename the constant to something else.
+  # 2. index.ts runs into "Type error: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'",
+  #    so apply the suggested fix to the offending exports.
+  - name: fix-openapi-client
+    taskRef:
+      name: script
+    runAfter:
+    - generate-api
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui
+    - name: script
+      value:
+        mkdir -p temp &&
+        promiseApiFile="galasa-ui/src/generated/galasaapi/PromiseAPI.ts" &&
+        cat ${promiseApiFile} | sed "s/const result =/const apiResult =/g" > temp/PromiseAPI-temp.ts &&
+        cat temp/PromiseAPI-temp.ts | sed "s/return result\.toPromise/return apiResult\.toPromise/g" > temp/PromiseAPI.ts &&
+        cp temp/PromiseAPI.ts ${promiseApiFile} &&
+        indexFile="galasa-ui/src/generated/galasaapi/index.ts" &&
+        cat ${indexFile} | sed "s/export { Configuration/export { type Configuration/1" > temp/index-temp.ts &&
+        cat temp/index-temp.ts | sed "s/export { PromiseMiddleware/export { type PromiseMiddleware/1" > temp/index.ts &&
+        cp temp/index.ts ${indexFile}
     workspaces:
      - name: git-workspace
        workspace: git-workspace
@@ -137,7 +201,7 @@ spec:
     taskRef:
       name: nodejs
     runAfter:
-    - generate-grpc-types
+    - fix-openapi-client
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui

--- a/pipelines/pipelines/galasa-ui/build-pr.yaml
+++ b/pipelines/pipelines/galasa-ui/build-pr.yaml
@@ -92,32 +92,15 @@ spec:
      - name: output
        workspace: git-workspace
 
-#----------------------------------------------------------------
-# Install the webui's dependencies
-  - name: npm-install-webui
-    taskRef:
-      name: nodejs
-    runAfter:
-    - clone-webui
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/webui/galasa-ui
-    - name: command
-      value:
-        - npm
-        - install
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-
   #----------------------------------------------------------------
-  # Call gradle to pull-down dependencies we need and put them in
-  # the correct places.
-  - name: gather-dependencies
+  # Call gradle to pull-down dependencies we need and put them in the correct places,
+  # before generating the TypeScript client code from the openapi.yaml so the webui can
+  # talk to the API server.
+  - name: generate-api
     taskRef:
       name: gradle-build
     runAfter:
-    - npm-install-webui
+    - clone-webui
     params:
     # The context indicates which folder the build.gradle is in.
     - name: context
@@ -129,42 +112,11 @@ spec:
         - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
     - name: command
       value:
-        - downloadDependencies
+        - generateTypeScriptClient
         - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace
-
-  #----------------------------------------------------------------
-  # Generate TypeScript client code from the openapi.yaml so the webui can
-  # talk to the API server.
-  - name: generate-api
-    taskRef:
-      name: general-command
-    runAfter:
-    - gather-dependencies
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/webui
-    - name: image
-      value: harbor.galasa.dev/common/openapi:main
-    - name: command
-      value:
-        - java
-        - -jar
-        - /opt/openapi/openapi-generator-cli.jar
-        - generate
-        - -i
-        - /workspace/git/$(context.pipelineRun.name)/webui/build/dependencies/openapi.yaml
-        - -g
-        - typescript
-        - -o
-        - galasa-ui/src/app/generated/galasaapi
-        - --additional-properties=packageName=galasaapi
-        - --global-property=apiTests=false
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
 
   #----------------------------------------------------------------
   # The generated TypeScript client code contains some compilation and build errors, which need fixing:
@@ -196,12 +148,30 @@ spec:
        workspace: git-workspace
 
 #----------------------------------------------------------------
+# Install the webui's dependencies
+  - name: npm-install-webui
+    taskRef:
+      name: nodejs
+    runAfter:
+    - fix-openapi-client
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/webui/galasa-ui
+    - name: command
+      value:
+        - npm
+        - install
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
+#----------------------------------------------------------------
 # Run the webui's unit tests
   - name: npm-test-webui
     taskRef:
       name: nodejs
     runAfter:
-    - fix-openapi-client
+    - npm-install-webui
     params:
     - name: context
       value: $(context.pipelineRun.name)/webui/galasa-ui

--- a/pipelines/pipelines/galasa-ui/build-pr.yaml
+++ b/pipelines/pipelines/galasa-ui/build-pr.yaml
@@ -107,13 +107,10 @@ spec:
       value: $(context.pipelineRun.name)/webui
     - name: buildArgs
       value:
-        - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/maven"
-        - "-PcentralMaven=https://repo.maven.apache.org/maven2/"
-        - "-PtargetMaven=/workspace/git/$(context.pipelineRun.name)/webui/repo"
+        - "-PsourceMaven=https://development.galasa.dev/main/maven-repo/framework"
     - name: command
       value:
         - generateTypeScriptClient
-        - --info
     workspaces:
     - name: git-workspace
       workspace: git-workspace
@@ -135,7 +132,7 @@ spec:
     - name: script
       value:
         mkdir -p temp &&
-        promiseApiFile="galasa-ui/src/generated/galasaapi/PromiseAPI.ts" &&
+        promiseApiFile="galasa-ui/src/generated/galasaapi/types/PromiseAPI.ts" &&
         cat ${promiseApiFile} | sed "s/const result =/const apiResult =/g" > temp/PromiseAPI-temp.ts &&
         cat temp/PromiseAPI-temp.ts | sed "s/return result\.toPromise/return apiResult\.toPromise/g" > temp/PromiseAPI.ts &&
         cp temp/PromiseAPI.ts ${promiseApiFile} &&

--- a/pipelines/pipelines/helm/build-branch.yaml
+++ b/pipelines/pipelines/helm/build-branch.yaml
@@ -24,7 +24,7 @@ spec:
 #
   tasks:
   - name: clone-automation
-    taskRef: 
+    taskRef:
       name: git-clone
     params:
     - name: url
@@ -139,3 +139,17 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
+
+  finally:
+  - name: report-failed-build
+    when:
+      - input: "$(tasks.status)"
+        operator: in
+        values: ["Failed"]
+    taskRef:
+      name: slack-post
+    params:
+    - name: pipelineName
+      value: $(context.pipeline.name)
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1568

Also added the report-failed-build step to the helm pipeline.