### PR TITLE
Update Pipeline and Task apiVersions to tekton.dev/v1

### DIFF
--- a/pipelines/pipelines/automation/build-branch.yaml
+++ b/pipelines/pipelines/automation/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-automation

--- a/pipelines/pipelines/automation/build-pr.yaml
+++ b/pipelines/pipelines/automation/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-automation

--- a/pipelines/pipelines/build-image-ghgverify.yaml
+++ b/pipelines/pipelines/build-image-ghgverify.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: build-image-ghverify

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-buildutils

--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-buildutils

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-cli

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-cli

--- a/pipelines/pipelines/codecoverage/codecoverage.yaml
+++ b/pipelines/pipelines/codecoverage/codecoverage.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: codecoverage

--- a/pipelines/pipelines/codecoverage/snapshot-main-to-codecov.yaml
+++ b/pipelines/pipelines/codecoverage/snapshot-main-to-codecov.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: snapshot-main-to-codecov

--- a/pipelines/pipelines/eclipse/build-branch.yaml
+++ b/pipelines/pipelines/eclipse/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-eclipse

--- a/pipelines/pipelines/eclipse/build-pr.yaml
+++ b/pipelines/pipelines/eclipse/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-eclipse

--- a/pipelines/pipelines/extensions/build-branch.yaml
+++ b/pipelines/pipelines/extensions/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-extensions

--- a/pipelines/pipelines/extensions/build-pr.yaml
+++ b/pipelines/pipelines/extensions/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-extensions

--- a/pipelines/pipelines/framework/build-branch.yaml
+++ b/pipelines/pipelines/framework/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-framework

--- a/pipelines/pipelines/framework/build-pr.yaml
+++ b/pipelines/pipelines/framework/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-framework

--- a/pipelines/pipelines/galasa-ui/build-branch.yaml
+++ b/pipelines/pipelines/galasa-ui/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-webui

--- a/pipelines/pipelines/galasa-ui/build-pr.yaml
+++ b/pipelines/pipelines/galasa-ui/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-webui

--- a/pipelines/pipelines/githubapp-copyright/build-branch.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-githubapp-copyright

--- a/pipelines/pipelines/githubapp-copyright/build-pr.yaml
+++ b/pipelines/pipelines/githubapp-copyright/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-githubapp-copyright

--- a/pipelines/pipelines/helm/build-branch.yaml
+++ b/pipelines/pipelines/helm/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-helm

--- a/pipelines/pipelines/inttests/build-branch.yaml
+++ b/pipelines/pipelines/inttests/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-integratedtests

--- a/pipelines/pipelines/inttests/build-pr.yaml
+++ b/pipelines/pipelines/inttests/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-integratedtests

--- a/pipelines/pipelines/isolated/build-branch.yaml
+++ b/pipelines/pipelines/isolated/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-isolated

--- a/pipelines/pipelines/isolated/build-pr.yaml
+++ b/pipelines/pipelines/isolated/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-isolated

--- a/pipelines/pipelines/managers/build-branch.yaml
+++ b/pipelines/pipelines/managers/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-managers

--- a/pipelines/pipelines/managers/build-pr.yaml
+++ b/pipelines/pipelines/managers/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-managers

--- a/pipelines/pipelines/maven/build-branch.yaml
+++ b/pipelines/pipelines/maven/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-maven

--- a/pipelines/pipelines/maven/build-pr.yaml
+++ b/pipelines/pipelines/maven/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-maven

--- a/pipelines/pipelines/obr-generic/build-branch.yaml
+++ b/pipelines/pipelines/obr-generic/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-obr-generic

--- a/pipelines/pipelines/obr-generic/build-pr.yaml
+++ b/pipelines/pipelines/obr-generic/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-obr-generic

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-obr

--- a/pipelines/pipelines/obr/build-pr.yaml
+++ b/pipelines/pipelines/obr/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-obr

--- a/pipelines/pipelines/recycle-ecosystem/recycle-ecosystem.yaml
+++ b/pipelines/pipelines/recycle-ecosystem/recycle-ecosystem.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: recycle-ecosystem

--- a/pipelines/pipelines/run-tests/run-tests.yaml
+++ b/pipelines/pipelines/run-tests/run-tests.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: run-tests

--- a/pipelines/pipelines/simplatform/build-branch.yaml
+++ b/pipelines/pipelines/simplatform/build-branch.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-simplatform

--- a/pipelines/pipelines/simplatform/build-pr.yaml
+++ b/pipelines/pipelines/simplatform/build-pr.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pr-simplatform

--- a/pipelines/pipelines/simple/simple-push.yaml
+++ b/pipelines/pipelines/simple/simple-push.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: simple

--- a/pipelines/pipelines/snapshots/snapshot-all-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-all-main-to-prod.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: snapshot-all-main-to-prod

--- a/pipelines/pipelines/snapshots/snapshot-buildutils-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-buildutils-main-to-prod.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: buildutils-snapshot-main-to-prod

--- a/pipelines/pipelines/snapshots/snapshot-inttests-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-inttests-main-to-prod.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: inttests-snapshot-main-to-prod

--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: snapshot-obr-main-to-prod

--- a/pipelines/pipelines/snapshots/snapshot-simplatform-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-simplatform-main-to-prod.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: snapshot-simplatform

--- a/pipelines/pipelines/webapp/build-webapp.yaml
+++ b/pipelines/pipelines/webapp/build-webapp.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: build-webapp

--- a/pipelines/tasks/argocd-cli.yaml
+++ b/pipelines/tasks/argocd-cli.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: argocd-cli

--- a/pipelines/tasks/galasabld-command.yaml
+++ b/pipelines/tasks/galasabld-command.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: galasabld

--- a/pipelines/tasks/galasactl-command.yaml
+++ b/pipelines/tasks/galasactl-command.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: galasactl

--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: general-command

--- a/pipelines/tasks/get-commit.yaml
+++ b/pipelines/tasks/get-commit.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: get-commit

--- a/pipelines/tasks/git-checkout.yaml
+++ b/pipelines/tasks/git-checkout.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-check-branch

--- a/pipelines/tasks/git-clean.yaml
+++ b/pipelines/tasks/git-clean.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-clean

--- a/pipelines/tasks/git-clone.yaml
+++ b/pipelines/tasks/git-clone.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-clone

--- a/pipelines/tasks/git-status.yaml
+++ b/pipelines/tasks/git-status.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-status

--- a/pipelines/tasks/git-verify.yaml
+++ b/pipelines/tasks/git-verify.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: git-verify

--- a/pipelines/tasks/go-build.yaml
+++ b/pipelines/tasks/go-build.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: go-build

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: gradle-build

--- a/pipelines/tasks/helm.yaml
+++ b/pipelines/tasks/helm.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: helm

--- a/pipelines/tasks/kaniko-builder.yaml
+++ b/pipelines/tasks/kaniko-builder.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: docker-build

--- a/pipelines/tasks/kubectl.yaml
+++ b/pipelines/tasks/kubectl.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: kubectl

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: make-with-params

--- a/pipelines/tasks/maven-build.yaml
+++ b/pipelines/tasks/maven-build.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: maven-build

--- a/pipelines/tasks/maven-gpg.yaml
+++ b/pipelines/tasks/maven-gpg.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: maven-gpg

--- a/pipelines/tasks/nodejs.yaml
+++ b/pipelines/tasks/nodejs.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: nodejs

--- a/pipelines/tasks/script.yaml
+++ b/pipelines/tasks/script.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: script

--- a/pipelines/tasks/slack-post.yaml
+++ b/pipelines/tasks/slack-post.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: slack-post

--- a/pipelines/tasks/tkn-cli.yaml
+++ b/pipelines/tasks/tkn-cli.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: tkn-cli

--- a/releasePipeline/argocd-synced/pipelines/branch-create-galasa.yaml
+++ b/releasePipeline/argocd-synced/pipelines/branch-create-galasa.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-create-galasa

--- a/releasePipeline/argocd-synced/pipelines/branch-delete-all.yaml
+++ b/releasePipeline/argocd-synced/pipelines/branch-delete-all.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-delete-all

--- a/releasePipeline/argocd-synced/pipelines/branch-tag-galasa.yaml
+++ b/releasePipeline/argocd-synced/pipelines/branch-tag-galasa.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: branch-tag-galasa

--- a/releasePipeline/argocd-synced/pipelines/deploy-maven-galasa.yaml
+++ b/releasePipeline/argocd-synced/pipelines/deploy-maven-galasa.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: deploy-maven-galasa

--- a/releasePipeline/argocd-synced/pipelines/full-regression.yaml
+++ b/releasePipeline/argocd-synced/pipelines/full-regression.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: full-regression

--- a/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
+++ b/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: regression-reruns

--- a/releasePipeline/argocd-synced/pipelines/resources-build.yaml
+++ b/releasePipeline/argocd-synced/pipelines/resources-build.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: resources-build


### PR DESCRIPTION
- Updated all Pipeline and Task apiVersions from `tekton.dev/v1beta1` to `tekton.dev/v1`

PipelineRuns may be affected by the change, so will change those in a separate PR.