### PR TITLE
Fixed duplicate parameter which was failing validation checks at v1

### DIFF
--- a/pipelines/pipelines/isolated/build-pr.yaml
+++ b/pipelines/pipelines/isolated/build-pr.yaml
@@ -1174,8 +1174,6 @@ spec:
       value:
         - "--tarPath"
         - "/workspace/git/$(context.pipelineRun.name)/isolated/mvp/target/isolated/isolated.tar"
-    - name: buildArgs
-      value:
         - "--build-arg=directory=isolated/mvp"
     workspaces:
       - name: git-workspace


### PR DESCRIPTION
Duplicate parameter of buildArgs failed validation checks for v1. Needed fixing anyway.