### PR TITLE
Remove unused grpc values

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -121,19 +121,12 @@ dex:
   # NodePorts to access Dex services through (Helm will dynamically assign NodePorts in the
   # 30000 to 32767 range if they are left blank).
   nodePorts:
-    grpc: 32000
     http: # blank - dynamically assigned
 
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
   # By default, etcd is used as the storage option for the Galasa Ecosystem.
   config:
     issuer: "https://galasa-ecosystem1.galasa.dev/dex"
-
-    # Enable Dex's gRPC API for clients to interact with.
-    grpc:
-      # The address of the exposed gRPC API server. Must be a valid {HOST}:{PORT} combination.
-      addr: "galasa-ecosystem1.galasa.dev:32000"
-      reflection: true
 
     connectors:
     - type: github


### PR DESCRIPTION
Related to https://github.com/galasa-dev/helm/pull/10 and https://github.com/galasa-dev/projectmanagement/issues/1568

Changes:
- The gRPC-related values for Dex are no longer used in the values.yaml file for the helm chart, so we can remove them