### PR TITLE
Update ecosystem1 Helm values

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -149,7 +149,7 @@ dex:
     staticClients:
     - id: galasa-webui
       redirectURIs:
-      - 'https://galasa-ecosystem1.galasa.dev/auth/callback'
+      - 'https://galasa-ecosystem1.galasa.dev/api/auth/callback'
       name: 'Galasa Ecosystem Web UI'
       # Use the webui client secret drawn from the secret mounted in envFrom
       secretEnv: webuiClientSecret
@@ -158,4 +158,5 @@ dex:
     expiry:
       idTokens: 24h
       refreshTokens:
+        reuseInterval: 8760h # 1 year
         validIfNotUsedFor: 8760h # 1 year


### PR DESCRIPTION
Related to https://github.com/galasa-dev/projectmanagement/issues/1568#issue-1899895762

- The redirect URL is now on the API server rather than the webui
- Added reuse interval setting to allow refresh tokens to be reused