### PR TITLE
Updated imagePullPolicy for Tasks that use mostly static images

### DIFF
--- a/dockerfiles/common/unzip-dockerfile
+++ b/dockerfiles/common/unzip-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:latest
+FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 RUN apt-get update && apt-get install -y unzip

--- a/dockerfiles/simple/Dockerfile
+++ b/dockerfiles/simple/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox:latest
+FROM busybox:1.36.1
 
 CMD ["/bin/echo", "'Hello World'"]

--- a/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: regression-test-new
+  name: regression-test
   namespace: galasa-prod
 spec:
   schedule: 0 6 * * * # Daily at 06:00
@@ -26,8 +26,8 @@ spec:
             - -R
             - "777"
             - /galasa
-            image: busybox
-            imagePullPolicy: Always
+            image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+            imagePullPolicy: IfNotPresent
             resources: {}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File

--- a/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
@@ -26,7 +26,7 @@ spec:
             - -R
             - "777"
             - /galasa
-            image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+            image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
             imagePullPolicy: IfNotPresent
             resources: {}
             terminationMessagePath: /dev/termination-log

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -71,7 +71,7 @@ spec:
 #
   - name: make
     taskRef:
-      name: make
+      name: make-with-params
     runAfter:
       - clone-buildutils  
     params:

--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -82,7 +82,7 @@ spec:
        workspace: git-workspace 
   - name: make
     taskRef:
-      name: make
+      name: make-with-params
     runAfter:
       - clone-buildutils  
     params:

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -215,7 +215,7 @@ spec:
   # gather code coverage stats.
   - name: galasactl-make
     taskRef:
-      name: make
+      name: make-with-params
     runAfter:
     - get-commit
     params:

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -251,7 +251,7 @@ spec:
   # gather code coverage stats.
   - name: galasactl-make
     taskRef:
-      name: make
+      name: make-with-params
     runAfter:
     - get-commit
     params:

--- a/pipelines/pipelines/obr/build-branch.yaml
+++ b/pipelines/pipelines/obr/build-branch.yaml
@@ -388,7 +388,7 @@ spec:
         operator: in
         values: ["release"]
     taskRef:
-      name: make
+      name: make-with-params
     runAfter:
       - clone-buildutils
       - branch-docker-build-obr  

--- a/pipelines/tasks/argocd-cli.yaml
+++ b/pipelines/tasks/argocd-cli.yaml
@@ -24,7 +24,7 @@ spec:
   steps:
   - name: argocd-cli
     image: harbor.galasa.dev/common/argocd-cli:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: ARGOCD_AUTH_TOKEN
       valueFrom:

--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -20,7 +20,7 @@ spec:
     type: array
   - name: image
     type: string  
-    default: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+    default: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
   steps:
   - name: run-command
     workingDir: /workspace/git/$(params.context)

--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -25,6 +25,6 @@ spec:
   - name: run-command
     workingDir: /workspace/git/$(params.context)
     image: $(params.image)
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
       - $(params.command[*])

--- a/pipelines/tasks/get-commit.yaml
+++ b/pipelines/tasks/get-commit.yaml
@@ -22,7 +22,7 @@ spec:
   - name: get-commit
     workingDir: /workspace/git/$(params.pipelineRunName)/$(params.repo)
     image: harbor.galasa.dev/common/gitcli:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     script: |
       #!/bin/sh
       set +e

--- a/pipelines/tasks/git-checkout.yaml
+++ b/pipelines/tasks/git-checkout.yaml
@@ -22,7 +22,7 @@ spec:
   - name: run-script
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/common/gitcli:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: GITHUBTOKEN
       valueFrom:

--- a/pipelines/tasks/git-clean.yaml
+++ b/pipelines/tasks/git-clean.yaml
@@ -20,7 +20,7 @@ spec:
   steps:
   - name: clean-subdirectory
     workingDir: /workspace/git/
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - rm

--- a/pipelines/tasks/git-clean.yaml
+++ b/pipelines/tasks/git-clean.yaml
@@ -20,8 +20,8 @@ spec:
   steps:
   - name: clean-subdirectory
     workingDir: /workspace/git/
-    image: busybox:latest
-    imagePullPolicy: Always
+    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+    imagePullPolicy: IfNotPresent
     command:
     - rm
     - -rf

--- a/pipelines/tasks/go-build.yaml
+++ b/pipelines/tasks/go-build.yaml
@@ -33,7 +33,7 @@ spec:
   steps:
   - name: go-build
     workingDir: /workspace/go/src/$(params.context)
-    image: golang:latest
+    image: golang:1.20.1
     imagePullPolicy: Always
     env:
     - name: GOPATH

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -24,7 +24,7 @@ spec:
   - name: gradle-build
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
     - gradle
     args:

--- a/pipelines/tasks/helm.yaml
+++ b/pipelines/tasks/helm.yaml
@@ -21,8 +21,8 @@ spec:
   steps:
   - name: helm
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/alpine/helm:3.13.2
-    imagePullPolicy: Always
+    image: harbor.galasa.dev/docker_proxy_cache/alpine/helm:3.13.2
+    imagePullPolicy: IfNotPresent
     command:
       - helm
     args:

--- a/pipelines/tasks/kaniko-builder.yaml
+++ b/pipelines/tasks/kaniko-builder.yaml
@@ -32,7 +32,7 @@ spec:
   - name: docker-build
     workingDir: /workspace/git/$(params.pipelineRunName)
     image: gcr.io/kaniko-project/executor:v1.6.0
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     env:
     - name: DOCKER_CONFIG
       value: /root/.docker

--- a/pipelines/tasks/kubectl.yaml
+++ b/pipelines/tasks/kubectl.yaml
@@ -16,6 +16,6 @@ spec:
   steps:
   - name: kubectl
     image: harbor.galasa.dev/common/kubectl:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     args:
     - $(params.command)

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -16,13 +16,15 @@ spec:
   params:
   - name: directory
     type: string  
-  - name: params
+  - name: command
     type: array
     default: 
     - all
   steps:
   - name: make
     workingDir: /workspace/git/$(params.directory)
-    image: harbor.galasa.dev/docker_proxy_cache/library/golang:latest
+    image: harbor.galasa.dev/docker_proxy_cache/library/golang:1.20.1
     imagePullPolicy: IfNotPresent
-    command: ["make" , "$( params.params[*])" ]
+    command: 
+      - make
+      - $(params.command[*])

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -24,5 +24,5 @@ spec:
   - name: make
     workingDir: /workspace/git/$(params.directory)
     image: harbor.galasa.dev/docker_proxy_cache/library/golang:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command: ["make" , "$( params.params[*])" ]

--- a/pipelines/tasks/maven-build.yaml
+++ b/pipelines/tasks/maven-build.yaml
@@ -29,7 +29,7 @@ spec:
   - name: maven-build
     workingDir: /workspace/git/$(params.context)
     image: $(params.image)
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     # To authenticate to GitHub Packages during a Maven build
     env:
     - name: GITHUB_TOKEN_READ_PACKAGES_USERNAME

--- a/pipelines/tasks/maven-gpg.yaml
+++ b/pipelines/tasks/maven-gpg.yaml
@@ -22,7 +22,7 @@ spec:
   steps:
   - name: gpgdirectory
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - mkdir
@@ -54,7 +54,7 @@ spec:
       mountPath: /root/mavengpg
   - name: copy-settings
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
+    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - cp

--- a/pipelines/tasks/maven-gpg.yaml
+++ b/pipelines/tasks/maven-gpg.yaml
@@ -23,14 +23,14 @@ spec:
   - name: gpgdirectory
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
     - mkdir
     - $(params.settingsDirectory)
   - name: change-dir-permissions
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/common/gpg:latest
-    imagePullPolicy: Always
+    image: harbor.galasa.dev/common/gpg:main
+    imagePullPolicy: IfNotPresent
     command:
     - chmod
     - '700'
@@ -38,7 +38,7 @@ spec:
   - name: import-gpg
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/common/gpg:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
     - gpg
     - --homedir
@@ -55,7 +55,7 @@ spec:
   - name: copy-settings
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/docker_proxy_cache/library/busybox:latest
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
     - cp
     - /root/mavengpg/settings.xml

--- a/pipelines/tasks/script.yaml
+++ b/pipelines/tasks/script.yaml
@@ -25,7 +25,7 @@ spec:
   - name: script
     workingDir: /workspace/git/$(params.context)
     image: $(params.image)
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     script: |
       #!/bin/sh
       set +e

--- a/pipelines/tasks/script.yaml
+++ b/pipelines/tasks/script.yaml
@@ -20,7 +20,7 @@ spec:
     type: string
   - name: image
     type: string
-    default: busybox:latest 
+    default: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
   steps:
   - name: script
     workingDir: /workspace/git/$(params.context)

--- a/pipelines/tasks/tkn-cli.yaml
+++ b/pipelines/tasks/tkn-cli.yaml
@@ -22,7 +22,7 @@ spec:
   - name: tkn-cli
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/common/tkn:main
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command:
       - tkn
       - $(params.command[*])


### PR DESCRIPTION
- Updated the ubuntu tag from latest to 20.04 as we should be using exact versions to ensure reproducibility of images.
- Added new docker proxy cache location to images without explicit location as they default to pulling from Docker hub.
- Changed imagePullPolicy of images not in 'galasadev' to IfNotPresent. Each worker node in the cluster has an images cache and so this policy means it will only pull the image if an image exactly matching the sha does not exist in the cache. This decreases our pulls more and so avoids unnecessary traffic in the builds.