### PR TITLE
Add recycle-prod1 pipeline and snapshot-webui step

### DIFF
--- a/pipelines/pipelines/recycle-ecosystem/recycle-prod1.yaml
+++ b/pipelines/pipelines/recycle-ecosystem/recycle-prod1.yaml
@@ -1,0 +1,209 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: recycle-prod1
+  namespace: galasa-build
+spec:
+#
+#
+#
+  params:
+  - name: ecosystemNamespace
+    type: string
+    default: galasa-prod
+  - name: api
+    type: string
+    default: galasa-prod1-api
+  - name: engineController
+    type: string
+    default: galasa-prod1-engine-controller
+  - name: resourceMonitor
+    type: string
+    default: galasa-prod1-resource-monitor
+  - name: metrics
+    type: string
+    default: galasa-prod1-metrics
+  - name: webui
+    type: string
+    default: galasa-prod1-webui
+#
+#
+#
+  tasks:
+#
+#
+#
+  - name: recycle-api
+    taskRef:
+      name: kubectl
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - restart
+        - deployment/$(params.api)
+  - name: wait-api
+    taskRef:
+      name: kubectl
+    runAfter:
+    - recycle-api
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - status
+        - deployment/$(params.api)
+        - -w
+        - --timeout=3m
+#
+#
+#
+  - name: recycle-engine-controller
+    taskRef:
+      name: kubectl
+    runAfter:
+    - wait-api
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - restart
+        - deployment/$(params.engineController)
+  - name: wait-engine-controller
+    taskRef:
+      name: kubectl
+    runAfter:
+    - recycle-engine-controller
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - status
+        - deployment/$(params.engineController)
+        - -w
+        - --timeout=3m
+#
+#
+#
+  - name: recycle-resource-monitor
+    taskRef:
+      name: kubectl
+    runAfter:
+    - wait-api
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - restart
+        - deployment/$(params.resourceMonitor)
+  - name: wait-resource-monitor
+    taskRef:
+      name: kubectl
+    runAfter:
+    - recycle-resource-monitor
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - status
+        - deployment/$(params.resourceMonitor)
+        - -w
+        - --timeout=3m
+#
+#
+#
+  - name: recycle-metrics
+    taskRef:
+      name: kubectl
+    runAfter:
+    - wait-api
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - restart
+        - deployment/$(params.metrics)
+  - name: wait-metrics
+    taskRef:
+      name: kubectl
+    runAfter:
+    - recycle-metrics
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - status
+        - deployment/$(params.metrics)
+        - -w
+        - --timeout=3m
+#
+#
+#
+  - name: recycle-webui
+    taskRef:
+      name: kubectl
+    runAfter:
+    - wait-api
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - restart
+        - deployment/$(params.webui)
+  - name: wait-webui
+    taskRef:
+      name: kubectl
+    runAfter:
+    - recycle-webui
+    params:
+    - name: command
+      value: 
+        - -n 
+        - $(params.ecosystemNamespace)
+        - rollout
+        - status
+        - deployment/$(params.webui)
+        - -w
+        - --timeout=3m
+
+  finally:
+  - name: report-failed-build
+    when:
+      - input: "$(tasks.status)"
+        operator: in
+        values: ["Failed"]
+    taskRef:
+      name: slack-post
+    params:
+    - name: pipelineName
+      value: $(context.pipeline.name)
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: branchFlag
+      value: ""
+    - name: branch
+      value: ""

--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -30,7 +30,7 @@ spec:
 #
   tasks:
   - name: clone-automation
-    taskRef: 
+    taskRef:
       name: git-clone
     params:
     - name: url
@@ -53,12 +53,12 @@ spec:
     taskRef:
       name: docker-build
     runAfter:
-    - clone-automation  
+    - clone-automation
     params:
     - name: pipelineRunName
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/snapshots/repo-dockerfile
     - name: imageName
@@ -67,12 +67,12 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=dockerRepository=harbor.galasa.dev"         
-        - "--build-arg=image=galasa-obr"   
-        - "--build-arg=oldBranch=$(params.fromBranch)"   
+        - "--build-arg=dockerRepository=harbor.galasa.dev"
+        - "--build-arg=image=galasa-obr"
+        - "--build-arg=oldBranch=$(params.fromBranch)"
     workspaces:
      - name: git-workspace
-       workspace: git-workspace     
+       workspace: git-workspace
 #
 #
 #
@@ -85,13 +85,13 @@ spec:
     - name: server
       value: argocd.galasa.dev
     - name: command
-      value: 
-      - app 
-      - actions 
-      - run 
+      value:
+      - app
+      - actions
+      - run
       - $(params.appname)
-      - restart 
-      - --kind 
+      - restart
+      - --kind
       - Deployment
       - --resource-name
       - obr-$(params.imageTag)
@@ -107,16 +107,43 @@ spec:
     - name: server
       value: argocd.galasa.dev
     - name: command
-      value: 
-      - app 
+      value:
+      - app
       - wait
       - $(params.appname)
       - --resource
       - apps:Deployment:obr-$(params.imageTag)
       - --health
-# 
-# 
-# 
+#
+#
+#
+  - name: snapshot-webui
+    taskRef:
+      name: docker-build
+    runAfter:
+    - clone-automation
+    params:
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: dockerfilePath
+      value: automation/dockerfiles/snapshots/repo-dockerfile
+    - name: imageName
+      value: harbor.galasa.dev/galasadev/galasa-ui:$(params.toBranch)
+    - name: noPush
+      value: ""
+    - name: buildArgs
+      value:
+        - "--build-arg=dockerRepository=harbor.galasa.dev"
+        - "--build-arg=image=galasa-ui"
+        - "--build-arg=oldBranch=$(params.fromBranch)"
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+#
+#
+#
   - name: snapshot-boot-embedded
     taskRef:
       name: docker-build
@@ -124,9 +151,9 @@ spec:
     - clone-automation
     params:
     - name: pipelineRunName
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/snapshots/generic-dockerfile
     - name: imageName
@@ -135,12 +162,12 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=dockerRepository=harbor.galasa.dev"         
-        - "--build-arg=image=galasa-boot-embedded-amd64"   
-        - "--build-arg=oldBranch=$(params.fromBranch)"   
+        - "--build-arg=dockerRepository=harbor.galasa.dev"
+        - "--build-arg=image=galasa-boot-embedded-amd64"
+        - "--build-arg=oldBranch=$(params.fromBranch)"
     workspaces:
      - name: git-workspace
-       workspace: git-workspace       
+       workspace: git-workspace
 #
 #
 #
@@ -151,9 +178,9 @@ spec:
     - snapshot-boot-embedded
     params:
     - name: pipelineRunName
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: context
-      value: $(context.pipelineRun.name) 
+      value: $(context.pipelineRun.name)
     - name: dockerfilePath
       value: automation/dockerfiles/snapshots/generic-dockerfile
     - name: imageName
@@ -162,16 +189,16 @@ spec:
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=dockerRepository=harbor.galasa.dev"         
-        - "--build-arg=image=galasa-ibm-boot-embedded-amd64"   
-        - "--build-arg=oldBranch=$(params.fromBranch)"   
+        - "--build-arg=dockerRepository=harbor.galasa.dev"
+        - "--build-arg=image=galasa-ibm-boot-embedded-amd64"
+        - "--build-arg=oldBranch=$(params.fromBranch)"
     workspaces:
      - name: git-workspace
-       workspace: git-workspace  
+       workspace: git-workspace
 
-# 
+#
 # Recycle the galasa-prod Ecosystem which uses the 'prod' images
-# 
+#
   - name: trigger-recycle-ecosystem
     taskRef:
       name: tkn-cli
@@ -181,13 +208,13 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/automation
     - name: command
-      value: 
+      value:
       - pipeline
       - start
       - recycle-ecosystem
       - -n
       - galasa-build
-      - --prefix-name 
+      - --prefix-name
       - recycle-ecosystem
       - --use-param-defaults
       - --workspace
@@ -199,7 +226,7 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
-      
+
 # Trigger CLI rebuild after OBR code is promoted to production...
   - name: trigger-cli
     when:
@@ -214,13 +241,13 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/automation
     - name: command
-      value: 
+      value:
       - pipeline
       - start
       - branch-cli
       - -n
       - galasa-build
-      - --prefix-name 
+      - --prefix-name
       - trigger-cli-main
       - --use-param-defaults
       - --workspace
@@ -231,7 +258,7 @@ spec:
       - galasa-build-bot
     workspaces:
      - name: git-workspace
-       workspace: git-workspace    
+       workspace: git-workspace
 
   finally:
   - name: report-failed-build

--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -227,37 +227,6 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
-#
-# Recycle the prod1 Ecosystem which uses the 'prod' images
-#
-  - name: trigger-recycle-prod1
-    taskRef:
-      name: tkn-cli
-    runAfter:
-    - snapshot-ibm-boot-embedded
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/automation
-    - name: command
-      value:
-      - pipeline
-      - start
-      - recycle-prod1
-      - -n
-      - galasa-build
-      - --prefix-name
-      - recycle-prod1
-      - --use-param-defaults
-      - --workspace
-      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
-      - --pod-template
-      - ./pipelines/templates/pod-template.yaml
-      - --serviceaccount
-      - galasa-build-bot
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-
 # Trigger CLI rebuild after OBR code is promoted to production...
   - name: trigger-cli
     when:

--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -227,6 +227,37 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
+#
+# Recycle the prod1 Ecosystem which uses the 'prod' images
+#
+  - name: trigger-recycle-prod1
+    taskRef:
+      name: tkn-cli
+    runAfter:
+    - snapshot-ibm-boot-embedded
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/automation
+    - name: command
+      value:
+      - pipeline
+      - start
+      - recycle-prod1
+      - -n
+      - galasa-build
+      - --prefix-name
+      - recycle-prod1
+      - --use-param-defaults
+      - --workspace
+      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
+      - --pod-template
+      - ./pipelines/templates/pod-template.yaml
+      - --serviceaccount
+      - galasa-build-bot
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+
 # Trigger CLI rebuild after OBR code is promoted to production...
   - name: trigger-cli
     when:


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1797

Changes:
- Added a `recycle-prod1` pipeline to restart the prod1 ecosystem's deployments
  - A trigger will be added in a separate PR once the prod1 ecosystem is fully functional
- Added a `snapshot-webui` step to the `snapshot-obr-main-to-prod` pipeline to create a "prod" image for the webui