### PR TITLE
Use generic-dockerfile image for snapshot-webui

### DIFF
--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -128,7 +128,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)
     - name: dockerfilePath
-      value: automation/dockerfiles/snapshots/repo-dockerfile
+      value: automation/dockerfiles/snapshots/generic-dockerfile
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasa-ui:$(params.toBranch)
     - name: noPush


### PR DESCRIPTION
Related to https://github.com/galasa-dev/automation/pull/506

Changes:
- Fixed failures when running snapshot-webui by using the `generic-dockerfile` image instead of `repo-dockerfile`