### PR TITLE
Remove unused deploytestcat goal in integratedtests pipelines

### DIFF
--- a/pipelines/pipelines/inttests/build-branch.yaml
+++ b/pipelines/pipelines/inttests/build-branch.yaml
@@ -126,13 +126,11 @@ spec:
         - "-Dgalasa.source.repo=https://development.galasa.dev/main/maven-repo/obr"
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/inttests/repo"
-        - "-Dgalasa.bootstrap=https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
-        - "-Dgalasa.skip.deploytestcatalog=true" 
-        - "-Dgalasa.skip.bundletestcatalog=false"     
+        - "-Dgalasa.skip.deploytestcatalog=true"
+        - "-Dgalasa.skip.bundletestcatalog=false"
     - name: command
       value: 
-        - deploy 
-        - dev.galasa:galasa-maven-plugin:deploytestcat
+        - deploy
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/pipelines/inttests/build-pr.yaml
+++ b/pipelines/pipelines/inttests/build-pr.yaml
@@ -141,13 +141,11 @@ spec:
         - "-Dgalasa.source.repo=https://development.galasa.dev/main/maven-repo/obr"
         - "-Dgalasa.central.repo=https://repo.maven.apache.org/maven2/"
         - "-Dgalasa.release.repo=file:/workspace/git/$(context.pipelineRun.name)/inttests/repo"
-        - "-Dgalasa.bootstrap=https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
-        - "-Dgalasa.skip.deploytestcatalog=true" 
+        - "-Dgalasa.skip.deploytestcatalog=true"
         - "-Dgalasa.skip.bundletestcatalog=false"
     - name: command
-      value: 
-        - deploy 
-        - dev.galasa:galasa-maven-plugin:deploytestcat
+      value:
+        - deploy
     workspaces:
      - name: git-workspace
        workspace: git-workspace


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1747

Changes:
- Removed `deploytestcat` goal and associated bootstrap parameter in inttests pipelines since the pipelines already skip the deployment of the testcatalog with `-Dgalasa.skip.deploytestcatalog=true`