### PR TITLE
Run ecosystem tests on prod1 instead of prod in CLI builds

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -332,7 +332,7 @@ spec:
       value: 
         - ./test-galasactl-ecosystem.sh
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -367,7 +367,7 @@ spec:
       value: 
         - ./test-galasactl-ecosystem.sh
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
     workspaces:
      - name: git-workspace
        workspace: git-workspace


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1747

Changes:
- Change the bootstrap URL in CLI builds to prod1 when running ecosystem test scripts