### PR TITLE
Use prod1 bootstrap when launching integration tests

### DIFF
--- a/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
@@ -55,7 +55,7 @@ spec:
             - runs
             - prepare
             - --bootstrap
-            - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+            - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
             - --stream
             - inttests
             - --portfolio
@@ -83,7 +83,7 @@ spec:
             - runs
             - submit
             - --bootstrap
-            - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+            - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
             - --portfolio
             - /galasa/tests.yaml
             - --throttle

--- a/pipelines/pipelines/codecoverage/codecoverage.yaml
+++ b/pipelines/pipelines/codecoverage/codecoverage.yaml
@@ -199,7 +199,7 @@ spec:
         - --trace
     #
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
         - --throttle
         - '5'
         # - --throttlefile

--- a/pipelines/pipelines/run-tests/run-tests.yaml
+++ b/pipelines/pipelines/run-tests/run-tests.yaml
@@ -15,7 +15,7 @@ spec:
   params:
   - name: bootstrapUrl
     type: string
-    default: https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+    default: https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
   tasks:
   - name: clone-automation
     taskRef: 

--- a/releasePipeline/29-rerun-failed-tests.sh
+++ b/releasePipeline/29-rerun-failed-tests.sh
@@ -112,7 +112,7 @@ function download_galasactl {
 
 function get_failed_tests {
 
-    bootstrap="https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap"
+    bootstrap="https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap"
 
     cd ${BASEDIR}/temp
     mkdir -p home

--- a/releasePipeline/argocd-synced/pipelines/full-regression.yaml
+++ b/releasePipeline/argocd-synced/pipelines/full-regression.yaml
@@ -47,7 +47,7 @@ spec:
         - compilation
         - --trace
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
         - --throttle
         - '30'
         - --poll

--- a/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
+++ b/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
@@ -48,7 +48,7 @@ spec:
         # - --test
         # - <INSERT_HERE>
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
         - --log # Otherwise there is no output
         - "-"
     workspaces:
@@ -71,7 +71,7 @@ spec:
         - /workspace/git/$(context.pipelineRun.name)/test.yaml
         - --trace
         - --bootstrap
-        - https://galasa-galasa-prod.cicsk8s.hursley.ibm.com/bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
         - --throttle
         - '30'
         - --poll


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1747

Changes:
- Replaced references to the prod bootstrap with the prod1 bootstrap so that regression tests run on the prod1 ecosystem