### PR TITLE
Add GALASA_TOKEN env variable to the galasactl task, add ExternalSecret for prod1 auth token

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-galasa-prod1-token.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-galasa-prod1-token.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# This ExternalSecret creates a "galasa-prod1-token" Secret in the galasa-build namespace that 
+# contains a GALASA_TOKEN value, allowing build pipelines to authenticate with the prod1 ecosystem. 
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:  
+  name: galasa-prod1-token
+  namespace: galasa-build
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: galasa-prod1-token
+    template:
+      type: Opaque
+
+  data:
+  - secretKey: token
+    remoteRef:
+      property: token
+      key: galasa-secrets/galasa-prod1-token

--- a/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/regression-test.yaml
@@ -73,6 +73,12 @@ spec:
             resources: {}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
+            env:
+            - name: GALASA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: galasa-prod1-token
+                  key: token
             volumeMounts:
             - mountPath: /galasa
               name: static-files
@@ -105,6 +111,12 @@ spec:
             resources: {}
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
+            env:
+            - name: GALASA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: galasa-prod1-token
+                  key: token
             volumeMounts:
             - mountPath: /galasa
               name: static-files

--- a/pipelines/tasks/galasactl-command.yaml
+++ b/pipelines/tasks/galasactl-command.yaml
@@ -21,11 +21,24 @@ spec:
   - name: galasactlImageTag
     type: string
     default: main
+  - name: galasaTokenSecretName
+    type: string
+    default: galasa-prod1-token
+  - name: galasaTokenSecretKey
+    type: string
+    default: token
   steps:
   - name: galasactl
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:$(params.galasactlImageTag)
     imagePullPolicy: Always
+    env:
+    - name: GALASA_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: $(params.galasaTokenSecretName)
+          key: $(params.galasaTokenSecretKey)
+          optional: false
     command:
     - galasactl
     - $(params.command[*])


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1747

Changes:
- Added an ExternalSecret to create a Secret containing the auth token for prod1
- Added the GALASA_TOKEN environment variable to the galasactl task and the regression test CronJob