### PR TITLE
Pass auth token into CLI builds

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -252,7 +252,7 @@ spec:
 # 
   - name: test-galasactl-local-maven-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - chmod-local-script
     params:
@@ -260,9 +260,10 @@ spec:
       value: $(context.pipelineRun.name)/cli
     - name: image
       value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-openjdk-11
+    - name: entrypoint
+      value: ./test-galasactl-local.sh
     - name: command
-      value: 
-        - ./test-galasactl-local.sh
+      value:
         - --buildTool
         - maven
     workspaces:
@@ -273,17 +274,18 @@ spec:
 # 
   - name: test-galasactl-local-gradle-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - test-galasactl-local-maven-linux-x86-64
     params:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
+      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11
+    - name: entrypoint
+      value: ./test-galasactl-local.sh
     - name: command
-      value: 
-        - ./test-galasactl-local.sh
+      value:
         - --buildTool
         - gradle
     workspaces:
@@ -320,17 +322,20 @@ spec:
 #----------------------------------------------------------------
   - name: test-galasactl-ecosystem-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - chmod-ecosystem-script
     params:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/common/openjdk11-ibm:main 
+      value: harbor.galasa.dev/common/openjdk11-ibm:main
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
+    - name: entrypoint
+      value: ./test-galasactl-ecosystem.sh
     - name: command
-      value: 
-        - ./test-galasactl-ecosystem.sh
+      value:
         - --bootstrap
         - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
     workspaces:

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -288,7 +288,7 @@ spec:
 # 
   - name: test-galasactl-local-maven-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - chmod-local-script
     params:
@@ -296,9 +296,10 @@ spec:
       value: $(context.pipelineRun.name)/cli
     - name: image
       value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-openjdk-11
+    - name: entrypoint
+      value: ./test-galasactl-local.sh
     - name: command
-      value: 
-        - ./test-galasactl-local.sh
+      value:
         - --buildTool
         - maven
     workspaces:
@@ -309,7 +310,7 @@ spec:
 # 
   - name: test-galasactl-local-gradle-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - test-galasactl-local-maven-linux-x86-64
     params:
@@ -317,9 +318,10 @@ spec:
       value: $(context.pipelineRun.name)/cli
     - name: image
       value: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
+    - name: entrypoint
+      value: ./test-galasactl-local.sh
     - name: command
-      value: 
-        - ./test-galasactl-local.sh
+      value:
         - --buildTool
         - gradle
     workspaces:
@@ -355,7 +357,7 @@ spec:
 #----------------------------------------------------------------
   - name: test-galasactl-ecosystem-linux-x86-64
     taskRef: 
-      name: general-command
+      name: galasactl
     runAfter:
       - chmod-ecosystem-script
     params:
@@ -363,9 +365,12 @@ spec:
       value: $(context.pipelineRun.name)/cli
     - name: image
       value: harbor.galasa.dev/common/openjdk11-ibm:main 
+    - name: entrypoint
+      value: ./test-galasactl-ecosystem.sh
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
-      value: 
-        - ./test-galasactl-ecosystem.sh
+      value:
         - --bootstrap
         - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
     workspaces:

--- a/pipelines/pipelines/run-tests/run-tests.yaml
+++ b/pipelines/pipelines/run-tests/run-tests.yaml
@@ -17,6 +17,9 @@ spec:
     type: string
     default: https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
   tasks:
+#
+#
+#
   - name: clone-automation
     taskRef: 
       name: git-clone
@@ -34,6 +37,9 @@ spec:
     workspaces:
      - name: output
        workspace: git-workspace
+#
+#
+#
   - name: run-prepare
     taskRef: 
       name: galasactl
@@ -42,6 +48,10 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)
+    - name: image
+      value: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:stable
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
       value:
         - runs 
@@ -60,11 +70,12 @@ spec:
         - galasaecosystem.docker.version=main
         - --log
         - '-'
-    - name: galasactlImageTag
-      value: stable
     workspaces:
      - name: git-workspace
-       workspace: git-workspace   
+       workspace: git-workspace
+#
+#
+#
   - name: run-submit
     taskRef: 
       name: galasactl
@@ -73,6 +84,10 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)
+    - name: image
+      value: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:stable
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
       value:
         - runs 
@@ -99,12 +114,11 @@ spec:
         - junit.xml
         - --log
         - '-'
-    - name: galasactlImageTag
-      value: stable
     workspaces:
      - name: git-workspace
        workspace: git-workspace       
-
+#
+#
 # Snapshot the Main OBR to Prod now we have confirmed no environmental problems introduced
   - name: trigger-snapshot-obr-main-to-prod
     taskRef:
@@ -133,7 +147,9 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
-
+#
+#
+#
   finally:
   - name: report-failed-build
     when:

--- a/pipelines/tasks/galasactl-command.yaml
+++ b/pipelines/tasks/galasactl-command.yaml
@@ -16,25 +16,31 @@ spec:
   params:
   - name: context
     type: string
+  - name: entrypoint
+    type: string
+    default: galasactl
   - name: command
     type: array
-  - name: galasactlImageTag
+  - name: image
     type: string
-    default: main
+    default: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:main
   - name: galasaTokenSecretName
     type: string
     default: galasa-prod1-token
   - name: galasaTokenSecretKey
     type: string
     default: token
+  - name: galasaHome
+    type: string
+    default: ""
   steps:
   - name: galasactl
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/galasadev/galasa-cli-ibm-amd64:$(params.galasactlImageTag)
+    image: $(params.image)
     imagePullPolicy: Always
     env:
     - name: GALASA_HOME
-      value: /workspace/git/$(params.context)
+      value: $(params.galasaHome)
     - name: GALASA_TOKEN
       valueFrom:
         secretKeyRef:
@@ -42,5 +48,5 @@ spec:
           key: $(params.galasaTokenSecretKey)
           optional: false
     command:
-    - galasactl
+    - $(params.entrypoint)
     - $(params.command[*])

--- a/releasePipeline/argocd-synced/pipelines/full-regression.yaml
+++ b/releasePipeline/argocd-synced/pipelines/full-regression.yaml
@@ -33,6 +33,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
       value: 
         - runs

--- a/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
+++ b/releasePipeline/argocd-synced/pipelines/regression-reruns.yaml
@@ -35,6 +35,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
       value: 
         - runs
@@ -63,6 +65,8 @@ spec:
     params:
     - name: context
       value: $(context.pipelineRun.name)
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
     - name: command
       value: 
         - runs


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/1473

Changes:
- Updated the CLI pipelines to use the galasactl-command task when running scripts to test galasactl
- Added `entrypoint`, `galasaHome`, and `image` parameters to the galasactl-command task to make it more configurable