### PR TITLE
Iss1772 - Creating ExternalSecrets for Secrets without

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-argocd-token.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-argocd-token.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# This is a token that is used to authenticate to argocd.galasa.dev
+# in the Task argocd-cli in the build pipelines that recycles applications.
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:  
+  name: argocd-token
+  namespace: galasa-build
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: argocd-token
+    template:
+      type: Opaque
+          
+  data:
+  - secretKey: argocd-token
+    remoteRef:
+      property: argocd-token
+      key: galasa-secrets/argocd-token

--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-icr-api-key.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-icr-api-key.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:  
+  name: icr-api-key
+  namespace: galasa-build
+  annotations:
+    tekton.dev/docker-0: https://icr.io/v2
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: icr-api-key
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "{{ .username }}"
+        password: "{{ .token }}"
+          
+  data:
+  - secretKey: username
+    remoteRef:
+      property: username
+      key: galasa-secrets/icr-api-key
+  - secretKey: password
+    remoteRef:
+      property: password
+      key: galasa-secrets/icr-api-key
+

--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-slack-webhook.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-slack-webhook.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:  
+  name: slack-webhook
+  namespace: galasa-build
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: vault-backend
+    kind: SecretStore
+  target:
+    name: slack-webhook
+    template:
+      type: Opaque
+          
+  data:
+  - secretKey: webhook
+    remoteRef:
+      property: webhook
+      key: galasa-secrets/slack-webhook

--- a/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
+++ b/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
@@ -12,7 +12,6 @@ metadata:
 secrets:
 - name: harbor-creds
 - name: icr-api-key
-- name: planb-harbor-creds
 - name: github-enterprise-credentials
 ---
 kind: Role


### PR DESCRIPTION
- Also remove planb-harbor-creds from the galasa-build-bot ServiceAccount as it's not used and the credentials are invalid anyway.