### PR TITLE
Issue 1826 - Release the galasa-ui image in the release processes

### DIFF
--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -84,3 +84,9 @@ source $BASEDIR/20-build-all-code.sh
 ask_user_for_release_type
 set_kubernetes_context
 build_all_code
+
+h1 "run 21-build-webui.sh"
+source $BASEDIR/21-build-webui.sh
+ask_user_for_release_type
+set_kubernetes_context
+build_webui

--- a/releasePipeline/21-build-webui.sh
+++ b/releasePipeline/21-build-webui.sh
@@ -42,26 +42,16 @@ blue=$(tput setaf 25)
 # Headers and Logging
 #
 #-----------------------------------------------------------------------------------------                   
-underline() { printf "${underline}${bold}%s${reset}\n" "$@"
-}
-h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
-}
-h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
-}
-debug() { printf "${white}%s${reset}\n" "$@"
-}
-info() { printf "${white}➜ %s${reset}\n" "$@"
-}
-success() { printf "${green}✔ %s${reset}\n" "$@"
-}
-error() { printf "${red}✖ %s${reset}\n" "$@"
-}
-warn() { printf "${tan}➜ %s${reset}\n" "$@"
-}
-bold() { printf "${bold}%s${reset}\n" "$@"
-}
-note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
-}
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
 
 #-----------------------------------------------------------------------------------------                   

--- a/releasePipeline/21-build-webui.sh
+++ b/releasePipeline/21-build-webui.sh
@@ -1,0 +1,193 @@
+#! /usr/bin/env bash 
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Build the webui repository on release/prerelease branches.
+#
+# Environment variable over-rides:
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@"
+}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@"
+}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@"
+}
+debug() { printf "${white}%s${reset}\n" "$@"
+}
+info() { printf "${white}➜ %s${reset}\n" "$@"
+}
+success() { printf "${green}✔ %s${reset}\n" "$@"
+}
+error() { printf "${red}✖ %s${reset}\n" "$@"
+}
+warn() { printf "${tan}➜ %s${reset}\n" "$@"
+}
+bold() { printf "${bold}%s${reset}\n" "$@"
+}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@"
+}
+
+
+#-----------------------------------------------------------------------------------------                   
+# Main logic.
+#-----------------------------------------------------------------------------------------                   
+
+mkdir -p temp
+
+function ask_user_for_release_type {
+    PS3="Select the type of release process please: "
+    select lng in release pre-release
+    do
+        case $lng in
+            "release")
+                export release_type="release"
+                break
+                ;;
+            "pre-release")
+                export release_type="prerelease"
+                break
+                ;;
+            *)
+            echo "Unrecognised input.";;
+        esac
+    done
+    echo "Chosen type of release process: ${release_type}"
+}
+
+
+function set_kubernetes_context {
+    h1 "Setting the kubernetes context to be cicsk8s, using namespace galasa-build"
+    kubectl config set-context cicsk8s --namespace=galasa-build
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then 
+        error "Failed. rc=${rc}"
+        exit 1
+    fi
+}
+
+
+
+function build_webui {
+
+    yaml_file="build_webui.yaml"
+
+    rm -f temp/${yaml_file}
+    cat << EOF > temp/${yaml_file}
+
+#
+# Copyright contributors to the Galasa project 
+#
+kind: PipelineRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: webui-build-
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  params:
+  - name: toBranch
+    value: ${release_type}
+  - name: imageTag
+    value: ${release_type}
+#
+# 
+# 
+  pipelineRef:
+    name: branch-webui
+  serviceAccountName: galasa-build-bot
+# 
+# 
+# 
+  podTemplate:
+    volumes:
+    - name: gradle-properties
+      secret:
+        secretName: gradle-properties
+    - name: gpg-key
+      secret:
+        secretName: gpg-key
+    - name: mavengpg
+      secret:
+        secretName: mavengpg
+    - name: githubcreds
+      secret:
+        secretName: github-token
+    - name: harborcreds
+      secret:
+        secretName: harbor-creds-yaml
+    - name: mavencreds
+      secret:
+        secretName: maven-creds
+  workspaces:
+  - name: git-workspace
+    volumeClaimTemplate:
+      spec:
+        storageClassName: longhorn-temp
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+
+EOF
+
+    output=$(kubectl -n galasa-build create -f temp/${yaml_file})
+    # Outputs a line of text like this: 
+    # pipelinerun.tekton.dev/webui-build-8cbj8 created
+    rc=$?
+    if [[ "${rc}" != "0" ]]; then
+        error "Failed to start the webui build pipeline. rc=$?"
+        exit 1
+    fi
+    info "kubectl create pipeline run output: $output"
+
+
+    pipeline_run_name=$(echo $output | grep "created" | cut -f1 -d" " | xargs)
+
+
+    success "Branch build for the Galasa Web UI kicked off."
+    bold "Now use the tekton dashboard to monitor it."
+}
+
+if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
+  ask_user_for_release_type
+  set_kubernetes_context
+  build_all_code
+fi

--- a/releasePipeline/34-deploy-docker-galasa.sh
+++ b/releasePipeline/34-deploy-docker-galasa.sh
@@ -108,6 +108,7 @@ run_command docker pull harbor.galasa.dev/galasadev/galasa-javadoc-site:$FROM
 run_command docker pull harbor.galasa.dev/galasadev/galasa-restapidoc-site:$FROM
 run_command docker pull harbor.galasa.dev/galasadev/galasa-boot-embedded-amd64:$FROM
 run_command docker pull icr.io/galasadev/galasa-resources:$FROM
+run_command docker pull harbor.galasa.dev/galasadev/galasa-ui:$FROM
 
 
 
@@ -124,6 +125,9 @@ run_command docker tag harbor.galasa.dev/galasadev/galasa-boot-embedded-amd64:$F
 run_command docker tag icr.io/galasadev/galasa-resources:$FROM       \
            icr.io/galasadev/galasa-resources:$TO
 
+run_command docker tag harbor.galasa.dev/galasadev/galasa-ui:$FROM       \
+           icr.io/galasadev/galasa-ui:$TO
+
 run_command docker tag harbor.galasa.dev/galasadev/galasa-javadoc-site:$FROM                \
            icr.io/galasadev/galasa-javadoc-amd64:latest
 
@@ -136,12 +140,16 @@ run_command docker tag harbor.galasa.dev/galasadev/galasa-boot-embedded-amd64:$F
 run_command docker tag icr.io/galasadev/galasa-resources:$FROM      \
            icr.io/galasadev/galasa-resources:latest
 
+run_command docker tag harbor.galasa.dev/galasadev/galasa-ui:$FROM       \
+           icr.io/galasadev/galasa-ui:latest
+
 
 
 run_command docker push icr.io/galasadev/galasa-javadoc-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-restapidoc-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-resources:$TO
+run_command docker push icr.io/galasadev/galasa-ui:$TO
 
 
 
@@ -149,6 +157,7 @@ run_command docker push icr.io/galasadev/galasa-javadoc-amd64:latest
 run_command docker push icr.io/galasadev/galasa-restapidoc-amd64:latest
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:latest
 run_command docker push icr.io/galasadev/galasa-resources:latest
+run_command docker push icr.io/galasadev/galasa-ui:latest
 
 # And now for the CLI images...
 run_command docker pull harbor.galasa.dev/galasadev/galasa-cli-amd64:$FROM

--- a/releasePipeline/argocd-synced/pipelines/branch-create-galasa.yaml
+++ b/releasePipeline/argocd-synced/pipelines/branch-create-galasa.yaml
@@ -289,3 +289,27 @@ spec:
         - $(params.force)
         - --credentials
         - /creds/githubcreds.yaml
+# 
+# 
+# 
+  - name: clone-branch-webui
+    taskRef: 
+      name: galasabld
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: command
+      value:
+        - github
+        - branch
+        - copy
+        - --repository
+        - webui
+        - --to
+        - $(params.distBranch)
+        - --branch
+        - $(params.fromBranch)
+        - $(params.overwrite)
+        - $(params.force)
+        - --credentials
+        - /creds/githubcreds.yaml

--- a/releasePipeline/argocd-synced/pipelines/branch-delete-all.yaml
+++ b/releasePipeline/argocd-synced/pipelines/branch-delete-all.yaml
@@ -652,3 +652,23 @@ spec:
         - $(params.distBranch)
         - --credentials
         - /creds/githubcreds.yaml
+# 
+####### Web UI
+# 
+  - name: delete-branch-webui
+    taskRef:
+      name: galasabld
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: command
+      value: 
+        - github
+        - branch
+        - delete
+        - --repository
+        - webui
+        - --branch
+        - $(params.distBranch)
+        - --credentials
+        - /creds/githubcreds.yaml

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -34,7 +34,8 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
     1. Delete all Releases that were created: [Releases](https://github.com/galasa-dev/helm/releases) - Next to a Release, click the Delete icon and 'Delete this release'.
     2. Delete all Tags that were created: [Tags](https://github.com/galasa-dev/helm/tags) - Next to a Tag, click the three dots, then 'Delete Tag' then 'Delete this Tag'.
 7. Run [20-build-all-code.sh](./20-build-all-code.sh). When prompted, choose the '`pre-release`' option.
-8. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
+8. Run [21-build-webui.sh](./21-build-webui.sh). When prompted, choose the '`pre-release`' option.
+9. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - Each maven artifact should contain a file called com.auth0.jwt-<*VERSION*>.jar.asc. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
-9. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino or Will Yates to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+10. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino or Will Yates to perform the MEND scan to check for any vulnerabilities before moving onto the release process.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -34,7 +34,8 @@ For each of the Kubernetes Tekton command, you can follow with tkn -n galasa-bui
 ### Build and test the Galasa core components
 
 1. Run [20-build-all-code.sh](./20-build-all-code.sh). When prompted, choose the '`release`' option.
-2. Run [28-run-regression-tests.sh](./28-run-regression-tests.sh). All the tests must pass before moving on. For the ones which fail, run them individually:
+2. Run [21-build-webui.sh](./21-build-webui.sh). When prompted, choose the '`release`' option.
+3. Run [28-run-regression-tests.sh](./28-run-regression-tests.sh). All the tests must pass before moving on. For the ones which fail, run them individually:
 
    a. As currently some tests pass if run a second time due to the vaguaries of system resource availability. Also make sure @hobbit1983's VM image isn't down.
 


### PR DESCRIPTION
### Story
Resolves galasa-dev/projectmanagement#1826

### Why?
The ICR currently does not contain the galasa web UI image as it was not part of the release scripts or builds, so nobody could install an ecosystem without this.
This change set includes changes to both the prerelease and release processes:
- Clones the 'main' branch of the webui repo to 'release'
- Builds the 'release' branch to build the docker image galasa-ui:release
- This image is then deployed to ICR 
- The 'release' branch is cleaned up at the end of the release/prerelease process
- Additions to the release instructions to reflect these changes

