### PR TITLE
Fix icr-api-key password key

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-harbor-creds.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-harbor-creds.yaml
@@ -9,7 +9,7 @@
 
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
-metadata:  
+metadata:
   name: harbor-creds
   namespace: galasa-build
   annotations:
@@ -22,11 +22,14 @@ spec:
   target:
     name: harbor-creds
     template:
+      metadata:
+        annotations:
+          tekton.dev/docker-0: https://harbor.galasa.dev/v1
       type: kubernetes.io/basic-auth
       data:
         username: "{{ .username }}"
         password: "{{ .password }}"
-          
+
   data:
   - secretKey: username
     remoteRef:

--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-icr-api-key.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-icr-api-key.yaml
@@ -18,6 +18,9 @@ spec:
   target:
     name: icr-api-key
     template:
+      metadata:
+        annotations:
+          tekton.dev/docker-0: https://icr.io/v2
       type: kubernetes.io/basic-auth
       data:
         username: "{{ .username }}"


### PR DESCRIPTION
## Why?
Due to a recent change, the "password" key for the icr-api-key secret in Vault was not being pulled in as the ExternalSecret was looking for a "token" key, causing pushes to ICR to fail with an unauthorized error. Also, the `tekton.dev/docker-0` annotation was being created in the ExternalSecret rather than the Secret, so adding it to the secrets as well.