### PR TITLE
mcobbett 1813 local runs remote cps

### DIFF
--- a/pipelines/pipelines/automation/build-branch.yaml
+++ b/pipelines/pipelines/automation/build-branch.yaml
@@ -504,7 +504,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/common/openjdk11-ibm-gradle-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/common/openjdk11-ibm-gradle:$(params.headSha)
+      value: harbor.galasa.dev/common/openjdk11-ibm-gradle:$(params.branch)
     - name: noPush
       value: ""
     workspaces:

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -329,7 +329,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/common/openjdk11-ibm:main
+      value: harbor.galasa.dev/common/openjdk11-ibm-gradle:main
     - name: galasaHome
       value: /workspace/git/$(context.pipelineRun.name)
     - name: entrypoint

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -364,7 +364,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/common/openjdk11-ibm:main 
+      value: harbor.galasa.dev/common/openjdk11-ibm-gradle:main 
     - name: entrypoint
       value: ./test-galasactl-ecosystem.sh
     - name: galasaHome


### PR DESCRIPTION

## Why ?
See: [Local test run to be able to use remote CP #1813](https://github.com/galasa-dev/projectmanagement/issues/1813)

Trying to get the ecosystem tests running on the CLI pipeline such that it can use the hybrid configuration to run a test locally, and use the ecosystem's CPS.

## Changes
- cli pipeline to use ibm gradle image to run ecosystem tests.
- main branch build should not use SHA as image tag, but the branch name.
- cli pipeline pulls and uses the 'main' tagged image.

