### PR TITLE
renamed galasabld binary downloadables to reflect the addition of openapi2beans within them

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
@@ -6,5 +6,5 @@
 
 namespace: galasa-development
 branch: main
-imageName: harbor.galasa.dev/galasadev/galasabld-binary-downloadables
+imageName: harbor.galasa.dev/galasadev/buildutils-binary-downloadables
 imageTag: main

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -98,7 +98,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/buildutils/buildutils-binary-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasabld-binary-downloadables:$(params.imageTag)
+      value: harbor.galasa.dev/galasadev/buildutils-binary-downloadables:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs


### PR DESCRIPTION
galasabld downloadable binaries now contain openapi2beans binaries within, so renamed to fit the purpose better (i.e. buildutils downloadable binaries, because these binaries are all located in the buildutils repo)