### PR TITLE
Buildutils branch restructure

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/values.yaml
@@ -6,5 +6,5 @@
 
 namespace: galasa-development
 branch: main
-imageName: harbor.galasa.dev/galasadev/galasabld-binary-downloadables
+imageName: harbor.galasa.dev/galasadev/buildutils-binary-downloadables
 imageTag: main

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -98,7 +98,7 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/buildutils/buildutils-binary-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/galasabld-binary-downloadables:$(params.imageTag)
+      value: harbor.galasa.dev/galasadev/buildutils-binary-downloadables:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs

--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -82,6 +82,20 @@ spec:
        workspace: git-workspace 
 # 
 # 
+#
+  - name: make-openapi2beans
+    taskRef:
+      name: make-with-params
+    runAfter:
+      - clone-buildutils  
+    params:
+    - name: directory
+      value: $(context.pipelineRun.name)/buildutils/openapi2beans
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
+# 
+# 
 # 
   - name: build-buildutils-binary-downloadables
     taskRef:
@@ -177,20 +191,6 @@ spec:
       value:
         - "--build-arg=dockerRepository=harbor.galasa.dev"
         - "--build-arg=branch=$(params.imageTag)"
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-# 
-# 
-#
-  - name: make-openapi2beans
-    taskRef:
-      name: make-with-params
-    runAfter:
-      - clone-buildutils  
-    params:
-    - name: directory
-      value: $(context.pipelineRun.name)/buildutils/openapi2beans
     workspaces:
      - name: git-workspace
        workspace: git-workspace


### PR DESCRIPTION
in argocd the buildutils branch build pipeline fails to sync due to:
```
one or more objects failed to apply, reason: admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: invalid value: couldn't add link between build-buildutils-binary-downloadables and make-openapi2bean: task build-buildutils-binary-downloadables depends on make-openapi2bean but make-openapi2bean wasn't present in Pipeline: spec.tasks
```
so restructured so that the openapi2beans-make step is before the step that depends on it.