### PR TITLE
fixed spelling error causing build buildutils binary downloadables to…

### DIFF
--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -103,7 +103,7 @@ spec:
     runAfter:
     - clone-automation
     - make
-    - make-openapi2bean
+    - make-openapi2beans
     params:
     - name: pipelineRunName
       value: $(context.pipelineRun.name)


### PR DESCRIPTION
… not recognise the make openapi2beans step.

related to https://github.com/galasa-dev/projectmanagement/issues/529.
I misspelt something :D