### PR TITLE
corrected buildutils build pipelines openapi2beans amd64 references to...

### DIFF
--- a/pipelines/pipelines/buildutils/build-branch.yaml
+++ b/pipelines/pipelines/buildutils/build-branch.yaml
@@ -211,12 +211,12 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/openapi2beans/openapi2beans-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/openapi2beans-amd64:$(params.imageTag)
+      value: harbor.galasa.dev/galasadev/openapi2beans-x86_64:$(params.imageTag)
     - name: noPush
       value: ""
     - name: buildArgs
       value:
-        - "--build-arg=platform=linux-amd64"
+        - "--build-arg=platform=linux-x86_64"
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -186,12 +186,12 @@ spec:
     - name: dockerfilePath
       value: automation/dockerfiles/openapi2beans/openapi2beans-dockerfile
     - name: imageName
-      value: harbor.galasa.dev/galasadev/openapi2beans-amd64:$(params.headSha)
+      value: harbor.galasa.dev/galasadev/openapi2beans-x86_64:$(params.headSha)
     - name: noPush
       value: "--no-push"
     - name: buildArgs
       value:
-        - "--build-arg=platform=linux-amd64"
+        - "--build-arg=platform=linux-x86_64"
     workspaces:
      - name: git-workspace
        workspace: git-workspace


### PR DESCRIPTION
... x86_64 to match up with what openapi2beans is building in the makefile
hopefully this will allow https://github.com/galasa-dev/buildutils/pull/43 to build.