### PR TITLE
removed no-push flag from build buildutils pr since it shouldn't be p…

### DIFF
--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -122,7 +122,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasabld-amd64:$(params.headSha)
     - name: noPush
-      value: --no-push
+      value: ""
     - name: buildArgs
       value:
         - "--build-arg=platform=linux-amd64"

--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -122,7 +122,7 @@ spec:
     - name: imageName
       value: harbor.galasa.dev/galasadev/galasabld-amd64:$(params.headSha)
     - name: noPush
-      value: ""
+      value: --no-push
     - name: buildArgs
       value:
         - "--build-arg=platform=linux-amd64"

--- a/pipelines/tasks/openapi2beans-command.yaml
+++ b/pipelines/tasks/openapi2beans-command.yaml
@@ -37,6 +37,7 @@ spec:
     imagePullPolicy: Always
     command:
     - openapi2beans
+    - generate
     - --yaml
     - $(params.yaml-location)
     - --output


### PR DESCRIPTION
…ushing on a pr, and fixed the openapi2beans command in it's task since it was just outputting the help function for openapi2beans