### PR TITLE
Add JWT username claims to ecosystem1 values now that they are required

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -115,9 +115,12 @@ dex:
     - secretRef:
         name: galasa-ecosystem1-dex-webui-client
 
-  # Optional - An ordered list of JSON Web Token (JWT) claims to use when Galasa sets the requestor of a test.
+  # An ordered list of JSON Web Token (JWT) claims to use when Galasa sets the requestor of a test.
   # The first JWT claim that is matched will be used as the requestor of a test.
-  usernameClaims: []
+  usernameClaims:
+    - preferred_username
+    - name
+    - sub
 
   # The Dex configuration - See the [Dex documentation](https://dexidp.io/docs) for more information.
   # By default, etcd is used as the storage option for the Galasa Ecosystem.


### PR DESCRIPTION
## Why?
Related to changes for https://github.com/galasa-dev/projectmanagement/issues/1805, in https://github.com/galasa-dev/framework/pull/546#discussion_r1609672470

The JWT claims used to retrieve usernames now need to be done by the user rather than falling back to a default set of claims to check from. This PR adds a set of JWT claims that could be used to retrieve usernames for ecosystem1.