### PR TITLE
removed galasabld-ibm-executable from the pr pipeline...

### DIFF
--- a/pipelines/pipelines/buildutils/build-pr.yaml
+++ b/pipelines/pipelines/buildutils/build-pr.yaml
@@ -128,33 +128,7 @@ spec:
         - "--build-arg=platform=linux-amd64"
     workspaces:
      - name: git-workspace
-       workspace: git-workspace 
-#
-#
-#
-  - name: build-galasabld-ibm-executable
-    taskRef:
-      name: docker-build
-    runAfter:
-    - build-galasabld-executable
-    params:
-    - name: pipelineRunName
-      value: $(context.pipelineRun.name)
-    - name: context
-      value: $(context.pipelineRun.name)/automation/dockerfiles/certs
-    - name: dockerfilePath
-      value: automation/dockerfiles/galasabld/galasabld-ibm-dockerfile
-    - name: imageName
-      value: harbor.galasa.dev/galasadev/galasabld-ibm-amd64:$(params.headSha)
-    - name: noPush
-      value: --no-push
-    - name: buildArgs
-      value:
-        - "--build-arg=dockerRepository=harbor.galasa.dev"
-        - "--build-arg=branch=$(params.headSha)"
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace 
+       workspace: git-workspace
 # 
 # 
 #


### PR DESCRIPTION
 as it depends on an image built earlier in the pipeline that doesn't push to harbor, so the step couldn't find it and it was breaking buildutils pr builds