### PR TITLE
Update ecosystem1 values to increase etcd space

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -43,9 +43,14 @@ nodeSelectors: {}
 storageClass: ""
 #
 #
+# The number of hours worth of etcd history to retain when etcd is compacted
+#
+etcdHistoryRetention: 10
+#
+#
 # The size of the persistent volumes for the data stores
 #
-etcdDiskSize: "1Gi"
+etcdDiskSize: "30Gi"
 couchdbDiskSize: "10Gi"
 catalogDiskSize: "1Gi"
 #


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1861

## Changes
- Upped the etcd PVC size from 1GB to 30GB in ecosystem1
- Added the `etcdHistoryRetention` value to configure the number of hours worth of history to be kept when compacting etcd for ecosystem1