### PR TITLE
Upgrade external sites for 0.34.1 release

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/javadoc-stable.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/javadoc-stable.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: javadoc-stable
-        image: icr.io/galasadev/galasa-javadoc-amd64:0.33.0
+        image: icr.io/galasadev/galasa-javadoc-amd64:0.34.0
         ports:
         - containerPort: 80
       affinity:

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/javadoc-stable.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/javadoc-stable.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: javadoc-stable
-        image: icr.io/galasadev/galasa-javadoc-amd64:0.34.0
+        image: icr.io/galasadev/galasa-javadoc-amd64:0.34.1
         ports:
         - containerPort: 80
       affinity:

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/resources.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/resources.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: resources
-        image: icr.io/galasadev/galasa-resources:0.34.0
+        image: icr.io/galasadev/galasa-resources:0.34.1
         ports:
         - containerPort: 80
       affinity:

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/resources.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/resources.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: resources
-        image: icr.io/galasadev/galasa-resources:0.33.0
+        image: icr.io/galasadev/galasa-resources:0.34.0
         ports:
         - containerPort: 80
       affinity:

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/restapidoc-stable.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/restapidoc-stable.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: restapidoc-stable
-        image: icr.io/galasadev/galasa-restapidoc-amd64:0.34.0
+        image: icr.io/galasadev/galasa-restapidoc-amd64:0.34.1
         ports:
         - containerPort: 80
       affinity:

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/restapidoc-stable.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/restapidoc-stable.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: restapidoc-stable
-        image: icr.io/galasadev/galasa-restapidoc-amd64:0.33.0
+        image: icr.io/galasadev/galasa-restapidoc-amd64:0.34.0
         ports:
         - containerPort: 80
       affinity:


### PR DESCRIPTION
### Why?
Upgrade the resources, javadoc, and rest api doc site to the 0.34.1 versions of the docker images.