### PR TITLE
Add internal-harbor-creds secret to ServiceAccount

### DIFF
--- a/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
+++ b/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: galasa-build
 secrets:
 - name: harbor-creds
+- name: internal-harbor-creds
 - name: icr-api-key
 - name: github-enterprise-credentials
 ---


### PR DESCRIPTION
### Why?

Make internal-harbor-creds Secret available to galasa-build-bot ServiceAccount.