### PR TITLE
Upgrading CPS properties for 0.35.0 release

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -159,7 +159,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.full.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.34.0/galasa-isolated-0.34.0.zip
+    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.35.0/galasa-isolated-0.35.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -167,7 +167,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.mvp.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.34.0/galasa-isolated-mvp-0.34.0.zip
+    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.35.0/galasa-isolated-mvp-0.35.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -215,7 +215,7 @@ metadata:
     namespace: galasaecosystem
     name: runtime.version
 data:
-    value: 0.34.0
+    value: 0.35.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty


### PR DESCRIPTION
Upgrading the CPS properties file with the new development version to allow the integration tests to run with the correct properties. I had previously done this manually with galasactl but as the PR with the CPS prop upgrade had not been merged, when an automation build ran, they were overwritten to the old value.