### PR TITLE
Reordered pipeline chain so run tests is after ecosystem recycle

### DIFF
--- a/pipelines/pipelines/galasa.dev/dummy-pipelines.yaml
+++ b/pipelines/pipelines/galasa.dev/dummy-pipelines.yaml
@@ -52,23 +52,4 @@ metadata:
 spec:
   workspaces:
   - name: git-workspace
-  params:
-  - name: headRef
-    type: string
-  - name: headSha
-    type: string
-  - name: baseRef
-    type: string
-  - name: prUrl
-    type: string
-  - name: statusesUrl
-    type: string
-  - name: issueUrl
-    type: string
-  - name: userId
-    type: string
-  - name: prNumber
-    type: string
-  - name: action
-    type: string
 

--- a/pipelines/pipelines/obr-generic/build-branch.yaml
+++ b/pipelines/pipelines/obr-generic/build-branch.yaml
@@ -304,6 +304,41 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
+#
+#
+#
+# Snapshot the Main OBR images to Prod
+  - name: trigger-snapshot-obr-main-to-prod
+    when:
+      - input: "$(params.toBranch)"
+        operator: in
+        values: ["main"]
+    taskRef:
+      name: tkn-cli
+    runAfter:
+    - branch-docker-build-ibm-embedded
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/automation
+    - name: command
+      value: 
+      - pipeline
+      - start
+      - snapshot-obr-main-to-prod
+      - -n
+      - galasa-build
+      - --prefix-name 
+      - trigger-snapshot-obr-main-to-prod
+      - --use-param-defaults
+      - --workspace
+      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
+      - --pod-template
+      - ./pipelines/templates/pod-template.yaml
+      - --serviceaccount
+      - galasa-build-bot
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace
 # 
 # 
 # 
@@ -339,39 +374,6 @@ spec:
     workspaces:
      - name: git-workspace
        workspace: git-workspace
-
-# Run a Core test against the Main OBR if doing a 'main' build...
-  - name: trigger-run-tests
-    when:
-      - input: "$(params.toBranch)"
-        operator: in
-        values: ["main"]
-    taskRef:
-      name: tkn-cli
-    runAfter:
-    - branch-docker-build-ibm-embedded
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/automation
-    - name: command
-      value: 
-      - pipeline
-      - start
-      - run-tests
-      - -n
-      - galasa-build
-      - --prefix-name 
-      - trigger-run-tests
-      - --use-param-defaults
-      - --workspace
-      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
-      - --pod-template
-      - ./pipelines/templates/pod-template.yaml
-      - --serviceaccount
-      - galasa-build-bot
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace  
 
 # Trigger CLI build if doing a 'prerelease' or a 'release'...
   - name: trigger-cli

--- a/pipelines/pipelines/recycle-ecosystem/recycle-prod1.yaml
+++ b/pipelines/pipelines/recycle-ecosystem/recycle-prod1.yaml
@@ -32,10 +32,35 @@ spec:
   - name: webui
     type: string
     default: galasa-prod1-webui
+# 
+# 
+# 
+  workspaces:
+  - name: git-workspace
 #
 #
 #
   tasks:
+#
+#
+#
+  - name: clone-automation
+    taskRef: 
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/automation
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/automation
+    workspaces:
+     - name: output
+       workspace: git-workspace
 #
 #
 #
@@ -189,6 +214,39 @@ spec:
         - deployment/$(params.webui)
         - -w
         - --timeout=3m
+
+  - name: trigger-run-tests
+    taskRef:
+      name: tkn-cli
+    runAfter:
+    - clone-automation
+    - wait-api
+    - wait-engine-controller
+    - wait-resource-monitor
+    - wait-metrics
+    - wait-webui
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/automation
+    - name: command
+      value: 
+      - pipeline
+      - start
+      - run-tests
+      - -n
+      - galasa-build
+      - --prefix-name 
+      - trigger-run-tests-prod1
+      - --use-param-defaults
+      - --workspace
+      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
+      - --pod-template
+      - ./pipelines/templates/pod-template.yaml
+      - --serviceaccount
+      - galasa-build-bot
+    workspaces:
+     - name: git-workspace
+       workspace: git-workspace  
 
   finally:
   - name: report-failed-build

--- a/pipelines/pipelines/run-tests/run-tests.yaml
+++ b/pipelines/pipelines/run-tests/run-tests.yaml
@@ -119,8 +119,9 @@ spec:
        workspace: git-workspace       
 #
 #
-# Snapshot the Main OBR to Prod now we have confirmed no environmental problems introduced
-  - name: trigger-snapshot-obr-main-to-prod
+#
+# Trigger CLI rebuild now we have confirmed ecosystem tests are running okay
+  - name: trigger-cli
     taskRef:
       name: tkn-cli
     runAfter:
@@ -129,14 +130,14 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/automation
     - name: command
-      value: 
+      value:
       - pipeline
       - start
-      - snapshot-obr-main-to-prod
+      - branch-cli
       - -n
       - galasa-build
-      - --prefix-name 
-      - trigger-snapshot-obr-main-to-prod
+      - --prefix-name
+      - trigger-cli-main
       - --use-param-defaults
       - --workspace
       - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml

--- a/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
+++ b/pipelines/pipelines/snapshots/snapshot-obr-main-to-prod.yaml
@@ -227,39 +227,6 @@ spec:
      - name: git-workspace
        workspace: git-workspace
 
-# Trigger CLI rebuild after OBR code is promoted to production...
-  - name: trigger-cli
-    when:
-      - input: "$(params.toBranch)"
-        operator: in
-        values: ["prod"]
-    taskRef:
-      name: tkn-cli
-    runAfter:
-    - snapshot-ibm-boot-embedded
-    params:
-    - name: context
-      value: $(context.pipelineRun.name)/automation
-    - name: command
-      value:
-      - pipeline
-      - start
-      - branch-cli
-      - -n
-      - galasa-build
-      - --prefix-name
-      - trigger-cli-main
-      - --use-param-defaults
-      - --workspace
-      - name=git-workspace,volumeClaimTemplateFile=./pipelines/templates/git-workspace-template.yaml
-      - --pod-template
-      - ./pipelines/templates/pod-template.yaml
-      - --serviceaccount
-      - galasa-build-bot
-    workspaces:
-     - name: git-workspace
-       workspace: git-workspace
-
   finally:
   - name: report-failed-build
     when:


### PR DESCRIPTION
## Why?

Currently the run-tests pipeline which runs a single test in the prod1 ecosystem to essentially check the health of prod1 is in the wrong place. It runs before the ecosystem has been recycled with any recent changes. The chain has been reordered:
- OBR is built
- Main are snapshot to Prod
- Prod1 is recycled
- run-tests is called to check the health of Prod1
- CLI is then built