### PR TITLE
Add GHCR credentials to the tekton service account

### DIFF
--- a/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
+++ b/pipelines/service-accounts/cicsk8s/galasa-build/galasa-build-bot.yaml
@@ -14,6 +14,7 @@ secrets:
 - name: internal-harbor-creds
 - name: icr-api-key
 - name: github-enterprise-credentials
+- name: ghcr-authentication
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is needed so we can pull images from GHCR in the current Tekton pipelines as we transition from the old to new builds.