### PR TITLE
Making the Tekton builds compatible with changes made for GH Actions

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gpg-key.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gpg-key.yaml
@@ -20,6 +20,7 @@ spec:
       type: Opaque
       data:
         galasa.gpg: "{{ .gpg | b64dec }}"
+        gpg-key: "{{ .gpg }}"
   data:
   - secretKey: gpg
     remoteRef:

--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gradle-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gradle-properties.yaml
@@ -24,6 +24,7 @@ spec:
           signing.keyId=221FFDC2
           signing.password={{ .password }}
           signing.secretKeyRingFile=/home/gradle/.gradle/galasa.gpg
+        password: "{{ .password }}"
   data:
   - secretKey: password
     remoteRef:

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -25,6 +25,21 @@ spec:
     workingDir: /workspace/git/$(params.context)
     image: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
     imagePullPolicy: IfNotPresent
+    env:
+    - name: ORG_GRADLE_PROJECT_signingKeyId
+      value: 221FFDC2
+    - name: ORG_GRADLE_PROJECT_signingKey
+      valueFrom:
+        secretKeyRef:
+          name: gpg-key
+          key: gpg-key
+          optional: false
+    - name: ORG_GRADLE_PROJECT_signingPassword
+      valueFrom:
+        secretKeyRef:
+          name: gradle-properties
+          key: password
+          optional: false
     command:
     - gradle
     args:


### PR DESCRIPTION
## Why?

To equip the new GH Actions workflow for the Gradle repository, the build.gradle file in the Gradle repo expects three environment variables for signing artefacts. I have now provided them in the gradle-build Task so the current Tekton builds aren't broken. This required some new data in the ExternalSecrets.