### PR TITLE
Use Gradle 8.9 instead of 6.8.2 for builds

### DIFF
--- a/dockerfiles/common/openjdk11-ibm-gradle-dockerfile
+++ b/dockerfiles/common/openjdk11-ibm-gradle-dockerfile
@@ -1,5 +1,5 @@
 
-FROM harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11
+FROM harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
 
 COPY ibmroot.pem  /etc/ssl/certs/ibmroot.pem
 COPY ibminter.pem /etc/ssl/certs/ibminter.pem

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -281,7 +281,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11
+      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -317,7 +317,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
+      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -23,7 +23,7 @@ spec:
   steps:
   - name: gradle-build
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/gradle:6.8.2-jdk11 
+    image: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11 
     imagePullPolicy: IfNotPresent
     env:
     - name: ORG_GRADLE_PROJECT_signingKeyId


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

## Changes
- Replaced the use of the Gradle 6.8.2 JDK 11 docker image with the Gradle 8.9 equivalent so that build pipelines use Gradle 8