### PR TITLE
Bump galasa-boot CPS property to 0.36.0

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -199,7 +199,7 @@ metadata:
     namespace: galasaecosystem
     name: galasaboot.version
 data:
-    value: 0.34.0
+    value: 0.36.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1652

## Changes
- Bumped the galasaboot.version CPS property to 0.36.0