### PR TITLE
Add dummy pipelines for buildutils

### DIFF
--- a/pipelines/pipelines/dummy-pipelines/dummy-pipelines.yaml
+++ b/pipelines/pipelines/dummy-pipelines/dummy-pipelines.yaml
@@ -53,3 +53,51 @@ spec:
   workspaces:
   - name: git-workspace
 
+---
+
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: pr-buildutils
+  namespace: galasa-build
+  # Tell ArgoCD never to prune this pipeline definition.
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  workspaces:
+  - name: git-workspace
+  params:
+  - name: headRef
+    type: string
+  - name: headSha
+    type: string
+  - name: baseRef
+    type: string
+  - name: prUrl
+    type: string
+  - name: statusesUrl
+    type: string
+  - name: issueUrl
+    type: string
+  - name: userId
+    type: string
+  - name: prNumber
+    type: string
+  - name: action
+    type: string
+
+---
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: branch-buildutils
+  namespace: galasa-build
+  # Tell ArgoCD never to prune this pipeline definition.
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  workspaces:
+  - name: git-workspace
+


### PR DESCRIPTION
## Why?

The event listener will attempt to call a pipeline for any repo with PRs or merges. The Tekton pipeline has been deleted and replaced by the GH workflow. This dummy pipeline avoids CouldntGetPipeline errors.