### PR TITLE
Add `galasaecosystem.runs.timeout` CPS prop for prod1

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -205,6 +205,14 @@ apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:
     namespace: galasaecosystem
+    name: runs.timeout
+data:
+    value: 10
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: galasaecosystem
     name: runtime.repository
 data:
     value: https://development.galasa.dev/main/maven-repo/obr


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1957

## Changes
- Added `galasaecosystem.runs.timeout` property, set to a timeout of 10mins, to the CPS properties applied for prod1