### PR TITLE
EventListener, Ingress and ConfigMap for new GH to Tekton trigger

### DIFF
--- a/build-images/github-webhook-monitor/config.yaml
+++ b/build-images/github-webhook-monitor/config.yaml
@@ -18,3 +18,5 @@ data:
         eventListener: "http://el-github-pr-review-builder-listener.galasa-build.svc.cluster.local:8080"
       push:
         eventListener: "http://el-github-main-builder-listener.galasa-build.svc.cluster.local:8080"
+      workflow_run:
+        eventListener: "http://el-github-workflow-completed-listener.galasa-build.svc.cluster.local:8080"

--- a/pipelines/event-listeners/ingress.yaml
+++ b/pipelines/event-listeners/ingress.yaml
@@ -47,3 +47,13 @@ spec:
               number: 8080
         path: /main
         pathType: Prefix
+  - host: triggers.galasa.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: el-github-workflow-completed-listener
+            port:
+              number: 8080
+        path: /workflow
+        pathType: Prefix

--- a/pipelines/event-listeners/workflow-completed.yaml
+++ b/pipelines/event-listeners/workflow-completed.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: github-workflow-completed-listener
+  annotations:
+    tekton.dev/payload-validation: "false"
+spec:
+  serviceAccountName: tekton-trigger
+  triggers:
+    - name: gitlab-push-events-trigger
+      interceptors:
+        - name: "validate GitHub payload and filter on eventType"
+          ref:
+            name: "github"
+          params:
+          - name: "eventTypes"
+            value: ["workflow_run"]
+        - name: "CEL filter: only when the workflow run was completed"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.action in ['completed']"
+        - name: "CEL filter: only when the workflow run was successful"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.workflow_run.conclusion in ['success']"
+        - name: "CEL filter: only when the workflow was for the OBR repository"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.repository.name in ['obr']"
+        - name: "CEL filter: only when the workflow branch was 'main'"
+          ref:
+            name: "cel"
+          params:
+          - name: "filter"
+            value: "body.workflow_run.head_branch in ['main']"
+       
+      template:
+        spec:
+          resourcetemplates:
+            - apiVersion: tekton.dev/v1beta1
+              kind: PipelineRun
+              metadata:
+                generateName: recycle-prod1-
+              spec:
+                pipelineRef:
+                  name: recycle-prod1
+                serviceAccountName: galasa-build-bot
+                podTemplate:
+                  volumes:
+                  - name: gradle-properties
+                    secret:
+                      secretName: gradle-properties
+                  - name: gpg-key
+                    secret:
+                      secretName: gpg-key
+                  - name: mavengpg
+                    secret:
+                      secretName: mavengpg
+                  - name: githubcreds
+                    secret:
+                      secretName: github-token
+                  - name: harborcreds
+                    secret:
+                      secretName: harbor-creds-yaml
+                  - name: mavencreds
+                    secret:
+                      secretName: maven-creds
+                workspaces:
+                - name: git-workspace
+                  volumeClaimTemplate:
+                    spec:
+                      storageClassName: longhorn-temp
+                      accessModes:
+                        - ReadWriteOnce
+                      resources:
+                        requests:
+                          storage: 20Gi


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1933 - to support triggering of the recycle-prod1 Tekton pipeline following a successful build of the OBR repo (and therefore the boot images).

- The workflow_run event type has been added to the galasa-dev org webhook so now needs adding to the ConfigMap to send this event type to the new EventListener
- The new EventListener filters all workflow_run events to only process completed, successful workflow runs of the OBR repository on the main branch
- The new EventListener's route has been added to the Ingress.