### PR TITLE
Update version bump docs to include helm and fix prerelease script

### DIFF
--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -14,9 +14,9 @@
 #-----------------------------------------------------------------------------------------     
 
 # Where is this script executing from ?
-BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+RELEASE_BASEDIR=$(dirname "$0");pushd $RELEASE_BASEDIR 2>&1 >> /dev/null ;RELEASE_BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 export ORIGINAL_DIR=$(pwd)
-cd "${BASEDIR}"
+cd "${RELEASE_BASEDIR}"
 CALLED_BY_PRERELEASE="true"
 export release_type="prerelease" 
 
@@ -54,26 +54,31 @@ note()      { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset
 #-----------------------------------------------------------------------------------------                   
 # Main Program
 #-----------------------------------------------------------------------------------------   
-set -e
-source $BASEDIR/02-create-argocd-apps.sh
-source $BASEDIR/03-repo-branches-delete.sh
-source $BASEDIR/04-repo-branches-create.sh
-source $BASEDIR/05-helm-charts.sh
-source $BASEDIR/20-build-all-code.sh
-source $BASEDIR/21-build-webui.sh
+function load_script {
+    cd ${RELEASE_BASEDIR}
+    script_path="$1"
 
+    source "${script_path}"
+}
+
+set -e
+
+load_script $RELEASE_BASEDIR/02-create-argocd-apps.sh
 h1 "run 02-create-argocd-apps.sh"
 create_maven_repos
 create_cli
 
+load_script $RELEASE_BASEDIR/03-repo-branches-delete.sh
 h1 "run 03-repo-branches-delete.sh"
 set_kubernetes_context
 delete_branches
 
+load_script $RELEASE_BASEDIR/04-repo-branches-create.sh
 h1 "run 04-repo-branches-create.sh"
 set_kubernetes_context
 create_branches
 
+load_script $RELEASE_BASEDIR/05-helm-charts.sh
 h1 "run 05-helm-charts.sh"
 get_galasa_version_to_be_released
 clone_helm_repository
@@ -81,11 +86,15 @@ get_helm_charts
 check_helm_charts_released
 delete_pre_release_helm_charts
 
+load_script $RELEASE_BASEDIR/20-build-all-code.sh
 h1 "run 20-build-all-code.sh"
 ask_user_for_release_type
 set_kubernetes_context
 build_all_code
 
+# This will need to be removed once the webui is built as part of the main build chain
+# (see https://github.com/galasa-dev/projectmanagement/issues/1960)
+load_script $RELEASE_BASEDIR/21-build-webui.sh
 h1 "run 21-build-webui.sh"
 ask_user_for_release_type
 set_kubernetes_context

--- a/releasePipeline/05-helm-charts.sh
+++ b/releasePipeline/05-helm-charts.sh
@@ -230,7 +230,7 @@ function delete_pre_release_helm_charts {
         release_url=$(grep -Ei ' *"url" *: *"(https:\/\/api\.github\.com\/repos\/galasa-dev\/helm\/releases\/[0-9]*)"' $release_json_details | cut -d \" -f 4)
 
         # Delete pre-release github release
-        response_code= $(curl -X DELETE $release_url -w "%{response_code}")
+        response_code= $(curl -X DELETE $release_url -w "${response_code}")
         if [[ "${response_code}" != "204" ]]; then 
             error "Unable to delete release for $release_tag using the api url '$release_url'. Expected status code '204' and got '$response_code'."
             exit 1

--- a/releasePipeline/99-move-to-new-version.md
+++ b/releasePipeline/99-move-to-new-version.md
@@ -99,3 +99,13 @@ These are manual steps to bump the version of Galasa to the next version.
     d. Push
 
     e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+
+8. Upgrade Helm charts
+
+    a. Create branch
+
+    b. Invoke the `set-version --version {new version}` script.
+    
+    c. Push
+
+    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.


### PR DESCRIPTION
## Why?
Related to findings during https://github.com/galasa-dev/projectmanagement/issues/1952

The pre-release script failed to run during the 0.36.0 release process since the `BASEDIR` was being overwritten each time a script was sourced, so this PR fixes issues with that script along with a typo in the `05-helm-charts.sh` script.

This PR also adds an additional step to bump the version of the ecosystem helm chart.