### PR TITLE
bump galasa boot version to prepare for jvm uplift

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -199,7 +199,7 @@ metadata:
     namespace: galasaecosystem
     name: galasaboot.version
 data:
-    value: 0.36.0
+    value: 0.37.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty


### PR DESCRIPTION
## Why?

bump galasa boot version to prepare for jvm uplift as changes are required to the launcher
