### PR TITLE
updated  to include jvm17 and later gradle version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -271,8 +271,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  build-openjdk11-ibm-gradle-image:
-    name: Build the 'openjdk11-ibm-gradle' image
+  build-openjdk17-ibm-gradle-image:
+    name: Build the 'openjdk17-ibm-gradle' image
     runs-on: ubuntu-latest
 
     steps:
@@ -290,26 +290,26 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openjdk11-ibm-gradle
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openjdk17-ibm-gradle
 
-      - name: Build 'openjdk11-ibm-gradle' Docker image
+      - name: Build 'openjdk17-ibm-gradle' Docker image
         if: github.event.pull_request.base.ref == 'main'
         id: build
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: dockerfiles/certs
-          file: dockerfiles/common/openjdk11-ibm-gradle-dockerfile
+          file: dockerfiles/common/openjdk17-ibm-gradle-dockerfile
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Build and push 'openjdk11-ibm-gradle' Docker image
+      - name: Build and push 'openjdk17-ibm-gradle' Docker image
         if: github.ref == 'refs/heads/main'
         id: build-push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: dockerfiles/certs
-          file: dockerfiles/common/openjdk11-ibm-gradle-dockerfile
+          file: dockerfiles/common/openjdk17-ibm-gradle-dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This directory is the single location for all Dockerfiles needed to build the im
 
 | Category | Dockerfiles |
 |----------|-------------|
-| Custom images (If there is not be a Docker official image that allows us to use a tool, we have created custom images to enable this. The Dockerfiles for all of the custom images are in the _dockerfiles/common_ directory) | argocd, ghstatus, ghverify, gitcli, github-monitor, github-receiver, gpg, kubectl, openapi, openjdk11-ibm-gradle, swagger, tkn | 
+| Custom images (If there is not be a Docker official image that allows us to use a tool, we have created custom images to enable this. The Dockerfiles for all of the custom images are in the _dockerfiles/common_ directory) | argocd, ghstatus, ghverify, gitcli, github-monitor, github-receiver, gpg, kubectl, openapi, openjdk17-ibm-gradle, swagger, tkn | 
 | Go programs | ghstatus, ghverify, github-webhook-monitor, github-webhook-receiver |
 | Base image (Most other images are built on top of this. Used to enable use of the Apache HTTP Server) | base |
 | Maven repositories for the built Galasa core components | wrapping, gradle, maven, framework, extensions, managers, obr, cli-binary, isolated |
@@ -618,9 +618,9 @@ Parameters:
 * settingsLocation: The location of the settings.xml produced by the maven-gpg task. This will normally be /workspace/git/PIPELINE_RUN_NAME/REPO/gpg/settings.xml. For the OBR builds, as two Maven builds occur in two different contexts, to avoid doing maven-gpg twice, the settingsLocation is set.
 * buildArgs: An array used for any additional arguments to pass to Maven.
 * command: An array of commands to use in the build such as 'deploy' or 'install'.
-* image: The Maven image to use for the task, defaults to Maven version 3.8.6 with the Open JDK 11.
+* image: The Maven image to use for the task, defaults to Maven version 3.8.6 with the IBM Semeru Java 17.
 
-This task uses the offical [Maven 3.8.6 with Open JDK 11 image](https://hub.docker.com/_/maven) from DockerHub unless overridden.
+This task uses the offical [Maven 3.8.6 with the IBM Semeru Java 17 image](https://hub.docker.com/_/maven) from DockerHub unless overridden.
 
 
 ### maven-gpg

--- a/dockerfiles/common/openjdk17-ibm-gradle-dockerfile
+++ b/dockerfiles/common/openjdk17-ibm-gradle-dockerfile
@@ -1,5 +1,5 @@
 
-FROM harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
+FROM harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
 
 COPY ibmroot.pem  /etc/ssl/certs/ibmroot.pem
 COPY ibminter.pem /etc/ssl/certs/ibminter.pem

--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -259,7 +259,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-openjdk-11
+      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command
@@ -281,7 +281,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
+      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command
@@ -329,7 +329,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: ghcr.io/galasa-dev/openjdk11-ibm-gradle:main
+      value: ghcr.io/galasa-dev/openjdk17-ibm-gradle:main
     - name: galasaHome
       value: /workspace/git/$(context.pipelineRun.name)
     - name: entrypoint

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -295,7 +295,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-openjdk-11
+      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command
@@ -317,7 +317,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11
+      value: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command
@@ -364,7 +364,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: ghcr.io/galasa-dev/openjdk11-ibm-gradle:main
+      value: ghcr.io/galasa-dev/openjdk17-ibm-gradle:main
     - name: entrypoint
       value: ./test-galasactl-ecosystem.sh
     - name: galasaHome

--- a/pipelines/pipelines/obr-generic/build-branch.yaml
+++ b/pipelines/pipelines/obr-generic/build-branch.yaml
@@ -273,7 +273,7 @@ spec:
       value:
         - "--build-arg=tag=$(params.fromBranch)"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
-        - "--build-arg=jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:11"
+        - "--build-arg=jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:17"
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/pipelines/obr-generic/build-pr.yaml
+++ b/pipelines/pipelines/obr-generic/build-pr.yaml
@@ -268,7 +268,7 @@ spec:
       value:
         - "--build-arg=tag=main"
         - "--build-arg=dockerRepository=harbor.galasa.dev"
-        - "--build-arg=jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:11"
+        - "--build-arg=jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:17"
     workspaces:
      - name: git-workspace
        workspace: git-workspace

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -23,7 +23,7 @@ spec:
   steps:
   - name: gradle-build
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk11 
+    image: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
     imagePullPolicy: IfNotPresent
     env:
     - name: ORG_GRADLE_PROJECT_signingKeyId

--- a/pipelines/tasks/maven-build.yaml
+++ b/pipelines/tasks/maven-build.yaml
@@ -24,7 +24,7 @@ spec:
     type: array
   - name: image
     type: string
-    default: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-openjdk-11
+    default: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
   steps:
   - name: maven-build
     workingDir: /workspace/git/$(params.context)


### PR DESCRIPTION
## Why?

This is to ensure that the repository can build on java 11 and java 17 JVMs
