### PR TITLE
Fix maven image that does not have gpg tool installed

### DIFF
--- a/pipelines/pipelines/cli/build-branch.yaml
+++ b/pipelines/pipelines/cli/build-branch.yaml
@@ -259,7 +259,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
+      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.5-openjdk-17
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -295,7 +295,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
+      value: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.5-openjdk-17
     - name: entrypoint
       value: ./test-galasactl-local.sh
     - name: command

--- a/pipelines/tasks/maven-build.yaml
+++ b/pipelines/tasks/maven-build.yaml
@@ -24,7 +24,7 @@ spec:
     type: array
   - name: image
     type: string
-    default: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.6-ibm-semeru-17-focal
+    default: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.5-openjdk-17
   steps:
   - name: maven-build
     workingDir: /workspace/git/$(params.context)


### PR DESCRIPTION
Change maven image used for maven build task to one with the `gpg` tool installed, version 3.8.5 so only 1 patch version lower than previously used version, and using openjdk again but version 17.