### PR TITLE
Add kube config secret into helm build workflow for ecosystem1

### DIFF
--- a/.github/workflows/build-helm.yaml
+++ b/.github/workflows/build-helm.yaml
@@ -1,45 +1,45 @@
-name: Helm Build
+name: Helm build (ecosystem1)
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 env:
-    NAMESPACE: galasa-dev
+  NAMESPACE: galasa-dev
 
 jobs:
-    build-helm:
-        name: Build Helm
-        runs-on: ubuntu-latest
+  build-helm:
+    name: Build Helm chart for ecosystem1
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout Automation Repo
-              uses: actions/checkout@v4
-            
-            - name: Checkout Helm Repo
-              uses: actions/checkout@v4  
-              with:
-               repository: ${{ env.NAMESPACE }}/helm
-               path: helmrepo
+    steps:
+      - name: Checkout Automation repository
+        uses: actions/checkout@v4
+      
+      - name: Checkout Helm repository
+        uses: actions/checkout@v4  
+        with:
+          repository: ${{ env.NAMESPACE }}/helm
+          path: helmrepo
 
-            - name: Setup helm
-              uses: azure/setup-helm@v4.2.0
-              with:
-                version: '3.13.2' # default is latest (stable)
-              id: install
-            
-            - name: setup kubeconfig secret
-              run: |
-               mkdir -p $HOME/.kube
-               echo "${{secrets.KUBECONFIG}}" >> $HOME/.kube/config
-            
-            - name: uninstall ecosystem
-              run: |
-                helm uninstall main-ecosystem --ignore-not-found --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
-            
-            - name: install ecosystem
-              run: |
-                helm install main-ecosystem ${{github.workspace}}/helmrepo/charts/ecosystem --namespace=galasa-ecosystem1 --values ${{github.workspace}}/automation/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml --kubeconfig $HOME/.kube/config --wait
+      - name: Setup helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: '3.13.2' # default is latest (stable)
+        id: install
+      
+      - name: Setup kubeconfig secret
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG_PLAN_B_CLUSTER }}" >> $HOME/.kube/config
+      
+      - name: Uninstall ecosystem1
+        run: |
+          helm uninstall main-ecosystem --ignore-not-found --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
+      
+      - name: Install ecosystem1
+        run: |
+          helm install main-ecosystem ${{ github.workspace }}/helmrepo/charts/ecosystem --namespace=galasa-ecosystem1 --values ${{ github.workspace }}/automation/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml --kubeconfig $HOME/.kube/config --wait
 
-            - name: test ecosystem
-              run: |
-                helm test main-ecosystem --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
+      - name: Test ecosystem1
+        run: |
+          helm test main-ecosystem --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config


### PR DESCRIPTION
## Why?

The helm build workflow which installs/uninstalls ecosystem1 needs the kube config for the Plan b cluster passed in as a secret. I've created the secret containing the config file in the org's secrets and called it `KUBE_CONFIG_PLAN_B_CLUSTER` so its different from any other kube configs we might store in future. I've updated the name of the secret in the workflow and improved the layout of the workflow.