### PR TITLE
Use GHCR images in ecosystem

### DIFF
--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/config.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/config.yaml
@@ -25,7 +25,7 @@ data:
 # The label for the engine pods and the prefix of the engine names
   engine_label: "k8s-standard-engine"
 #
-  engine_image: "harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod"
+  engine_image: "ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main"
   node_arch: "amd64"
 #  node_arch: ""
 #  node_preferred_affinity: "beta.kubernetes.io/arch=s390x"

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-api.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-api.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-engine-controller.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-engine-controller.yaml
@@ -28,7 +28,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-metrics.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: metrics
-        image: harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-resource-monitor.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-resource-monitor.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
@@ -52,7 +52,7 @@ spec:
           subPath: ""
       containers:
       - name: resource-monitor
-        image: harbor.galasa.dev/galasadev/galasa-ibm-boot-embedded-amd64:prod
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -31,7 +31,12 @@ galasaServiceName: "Galasa Ecosystem 1"
 #
 # The container registry the Galasa images can be found in
 #
-galasaRegistry: "harbor.galasa.dev/galasadev"
+galasaRegistry: "ghcr.io/galasa-dev"
+# 
+# 
+# The name of the Docker image that contains Galasa's boot.jar file to launch ecosystem services
+#
+galasaBootImage: "galasa-boot-embedded-amd64"
 #
 #
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes


### PR DESCRIPTION
Update the prod1 to use the new images in GHCR. Override the helm-values to do this also.

Note: We don't have prod tags as there is no snapshotting in our new process (can be added if we feel it's important) so for now pointing at the main images.