### PR TITLE
Fix image tag for webui and galasa boot to pull from ghcr

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -36,7 +36,12 @@ galasaRegistry: "ghcr.io/galasa-dev"
 # 
 # The name of the Docker image that contains Galasa's boot.jar file to launch ecosystem services
 #
-galasaBootImage: "galasa-boot-embedded-amd64"
+galasaBootImage: "galasa-boot-embedded-x86_64"
+#
+#
+# The name of the Docker image that launches Galasa's web UI
+#
+galasaWebUiImage: "webui"
 #
 #
 # The pull policy to be used for the Galasa images, only useful for Galasa development purposes


### PR DESCRIPTION
## Why?
Fixes ImagePullBackoff errors in ecosystem1 when attempting to pull the galasa boot and webui images from ghcr.