### PR TITLE
workflow_run event needs to point to 2 eventlistener urls

### DIFF
--- a/build-images/github-webhook-monitor/cmd/main.go
+++ b/build-images/github-webhook-monitor/cmd/main.go
@@ -227,13 +227,15 @@ func buildHookRequest(id string) (*http.Request, error) {
 			if err == nil {
 				eventType, ok := triggerMap.Events[request.Event]
 				if ok {
-					url := eventType.EventListener
-					payload, _ := json.Marshal(request.Request.Payload)
-					webhookRequest, err = http.NewRequest("POST", url, bytes.NewReader(payload))
-					if err == nil {
-						// Add headers
-						for k, v := range request.Request.Headers {
-							webhookRequest.Header.Add(k, v)
+					urls := eventType.EventListener
+					for _, url := range urls {
+						payload, _ := json.Marshal(request.Request.Payload)
+						webhookRequest, err = http.NewRequest("POST", url, bytes.NewReader(payload))
+						if err == nil {
+							// Add headers
+							for k, v := range request.Request.Headers {
+								webhookRequest.Header.Add(k, v)
+							}
 						}
 					}
 				} else {

--- a/build-images/github-webhook-monitor/config.yaml
+++ b/build-images/github-webhook-monitor/config.yaml
@@ -19,4 +19,4 @@ data:
       push:
         eventListener: "http://el-github-main-builder-listener.galasa-build.svc.cluster.local:8080"
       workflow_run:
-        eventListener: "http://el-github-workflow-completed-listener.galasa-build.svc.cluster.local:8080"
+        eventListener: ["http://el-github-obr-workflow-completed-listener.galasa-build.svc.cluster.local:8080","http://el-github-cli-workflow-completed-listener.galasa-build.svc.cluster.local:8080"]

--- a/build-images/github-webhook-monitor/pkg/mapper/types.go
+++ b/build-images/github-webhook-monitor/pkg/mapper/types.go
@@ -10,5 +10,5 @@ type Config struct {
 }
 
 type Event struct {
-	EventListener string `yaml:"eventListener"`
+	EventListener []string `yaml:"eventListener"`
 }


### PR DESCRIPTION
The github monitor's config map needs to provide the endpoints for the event listeners to know which event type to send there. The config map was missing the rename of the obr-complete event listener and was missing the new cli-complete listener. The Go code now needs to loop through an array of urls and send POST to both.