### PR TITLE
Parameterise inttest ingress to be able to deploy on different servers

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/templates/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/templates/deployment.yaml
@@ -27,6 +27,6 @@ spec:
           name: inttests-{{ .Values.branch }}
           env:
           - name: CONTEXTROOT
-            value: {{ .Values.branch }}/maven-repo/inttests
+            value: {{ .Values.branch }}/maven-repo/{{ .Values.ingress.pathSuffix }}
           ports:
             - containerPort: 80

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/templates/ingress.yaml
@@ -9,16 +9,18 @@ kind: Ingress
 metadata:
   name: inttests-{{ .Values.branch }}
   namespace: {{ .Values.namespace }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "public-iks-k8s-nginx"
-    
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- with .Values.ingress.tls }}
   tls:
-  - hosts:
-    - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
-  - host: development.galasa.dev
+  - host: {{ .Values.ingress.externalHostname }}
     http:
       paths:
       - backend:
@@ -26,5 +28,5 @@ spec:
             name: inttests-{{ .Values.branch }}
             port:
               number: 80
-        path: /{{ .Values.branch }}/maven-repo/{{ .Values.ingressPathSuffix }}
+        path: /{{ .Values.branch }}/maven-repo/{{ .Values.ingress.pathSuffix }}
         pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/values.yaml
@@ -8,4 +8,13 @@ namespace: galasa-development
 branch: main
 imageName: ghcr.io/galasa-dev/inttests-maven-artefacts
 imageTag: main
-ingressPathSuffix: inttests
+
+ingress:
+  externalHostname: development.galasa.dev
+  ingressClassName: public-iks-k8s-nginx
+  pathSuffix: inttests
+  annotations: {}
+  tls:
+  - hosts:
+      - development.galasa.dev
+    secretName: galasa-wildcard-cert


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/1749

In order to host the maven repo for the inttests that run internally, the Ingress needs to be able to point at a different host with different TLS settings. This PR updates the helm chart to allow this to be possible.

Also replaced a hardcoded CONTEXTROOT suffix with a value matching the Ingress path to allow the inttests to be served on different paths than `/{branch}/maven-repo/inttests`