### PR TITLE
Build internal integrated tests after the OBR

### DIFF
--- a/pipelines/event-listeners/obr-workflow-completed.yaml
+++ b/pipelines/event-listeners/obr-workflow-completed.yaml
@@ -57,6 +57,25 @@ spec:
                 pipelineRef:
                   name: recycle-prod1
                 serviceAccountName: galasa-build-bot
+                workspaces:
+                - name: git-workspace
+                  volumeClaimTemplate:
+                    spec:
+                      storageClassName: longhorn-temp
+                      accessModes:
+                        - ReadWriteOnce
+                      resources:
+                        requests:
+                          storage: 20Gi
+
+            - apiVersion: tekton.dev/v1beta1
+              kind: PipelineRun
+              metadata:
+                generateName: build-internal-integratedtests-
+              spec:
+                pipelineRef:
+                  name: build-internal-integratedtests
+                serviceAccountName: galasa-build-bot
                 podTemplate:
                   volumes:
                   - name: gradle-properties
@@ -65,18 +84,6 @@ spec:
                   - name: gpg-key
                     secret:
                       secretName: gpg-key
-                  - name: mavengpg
-                    secret:
-                      secretName: mavengpg
-                  - name: githubcreds
-                    secret:
-                      secretName: github-token
-                  - name: harborcreds
-                    secret:
-                      secretName: harbor-creds-yaml
-                  - name: mavencreds
-                    secret:
-                      secretName: maven-creds
                 workspaces:
                 - name: git-workspace
                   volumeClaimTemplate:


### PR DESCRIPTION
## Why?

The internal integratedtests should be rebuilt after the OBR is so that they have the latest Manager code, and latest galasa-bom to extract the versions from. The build pipelines for these tests have been added to the EventListener which will trigger when the main OBR workflow has completed in GitHub.