### PR TITLE
Add cli-binary-dockerfile

### DIFF
--- a/dockerfiles/cli/cli-binary-dockerfile
+++ b/dockerfiles/cli/cli-binary-dockerfile
@@ -1,0 +1,4 @@
+FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+RUN rm -v /usr/local/apache2/htdocs/*
+COPY automation/dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY cli/bin/galasactl* /usr/local/apache2/htdocs/


### PR DESCRIPTION
## Why?

I mistakenly advised that this wasn't used so it could be deleted, but was wrong.