### PR TITLE
Bump simbank CPS properties to 0.38.0

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -110,7 +110,7 @@ metadata:
     namespace: framework
     name: test.stream.simbank.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.15.0/obr
+    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.38.0/obr
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -231,7 +231,7 @@ metadata:
     namespace: galasaecosystem
     name: simbanktests.version
 data:
-    value: 0.25.0
+    value: 0.38.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/simplatform/pull/172

## Changes
- Bumped simbank CPS properties to 0.38.0 for use by prod1