### PR TITLE
Fix resources-dockerfile now its based on alpine

### DIFF
--- a/dockerfiles/release/resources/resources-dockerfile
+++ b/dockerfiles/release/resources/resources-dockerfile
@@ -2,11 +2,6 @@ FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
 ARG branch
 ARG version
 
-
-ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
-RUN apt-get update && apt-get install -y wget \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf
 


### PR DESCRIPTION
## Why?

A step in the 0.38.0 release process to build the Dockerfile failed as `apt-get` wasn't available to alpine.