### PR TITLE
Improvements for 0.39.0 release

### DIFF
--- a/releasePipeline/02-create-argocd-apps.sh
+++ b/releasePipeline/02-create-argocd-apps.sh
@@ -64,6 +64,21 @@ function create_maven_repos {
                     --helm-set mvp.deploy=true 
 }
 
+function create_bld {   
+    argocd app create ${release_type}-bld \
+                    --project default \
+                    --sync-policy auto \
+                    --sync-option Prune=true \
+                    --self-heal \
+                    --repo https://github.com/galasa-dev/automation \
+                    --revision HEAD  \
+                    --path infrastructure/galasa-plan-b-lon02/galasa-development/galasabld \
+                    --dest-server https://kubernetes.default.svc \
+                    --dest-namespace galasa-development \
+                    --helm-set branch=${release_type} \
+                    --helm-set imageTag=${release_type}
+}
+
 function create_cli {   
     argocd app create ${release_type}-cli \
                     --project default \
@@ -99,6 +114,7 @@ if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
     ask_user_for_release_type
     set -e
     create_maven_repos
+    create_bld
     create_cli
     create_simplatform
 fi

--- a/releasePipeline/92-delete-argocd-apps.sh
+++ b/releasePipeline/92-delete-argocd-apps.sh
@@ -7,9 +7,11 @@
 #
 
 argocd app delete release-maven-repos
+argocd app delete release-bld
 argocd app delete release-cli
 argocd app delete release-simplatform
 argocd app delete prerelease-maven-repos
+argocd app delete prerelease-bld
 argocd app delete prerelease-cli
 argocd app delete prerelease-simplatform
 

--- a/releasePipeline/95-move-to-new-version.md
+++ b/releasePipeline/95-move-to-new-version.md
@@ -8,22 +8,19 @@ These are manual steps to bump the version of Galasa to the next version.
 
     a. Create branch
 
-    b. Invoke the `set-version --version {new version}` script in each of these modules in order:
+    b. Invoke the `./tools/set-version --version {new version}` script in which invokes a separate `set-version.sh` for each module.
 
-        i. Framework
-        ii. Extensions
-        iii. Managers
-        iv. OBR
+    c. Currently not all versions are found by the script alone such as dev.galasa.platform's version used throughout the code, so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded.
 
-    c. Make sure it builds with `./tools/build-locally.sh --module framework --chain true` which will invoke each individual module's `build-locally.sh` script
+    d. Make sure it builds with `./tools/build-locally.sh` which will invoke each individual module's `build-locally.sh` script. Make sure the API Server starts locally also.
 
-    d. Push the changes to your branch
+    e. Push the changes to your branch
 
-    e. Open PR for this change and wait for the PR build to pass
+    f. Open PR for this change and wait for the PR build to pass
 
-    f. Merge in the PR
+    g. Merge in the PR and wait for the Main build to pass and finish
 
-    g. Upgrade the `galasaecosystem.runtime.version` CPS property with the release version value, for example: `galasactl properties set --namespace galasaecosystem --name runtime.version  --value 0.35.0 --bootstrap https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap`. This is needed so the 'run-tests' pipeline will pass in the next step.
+    **Note:** Once the Galasa mono repo's build finishes, this will trigger the `recycle-prod1` Tekton pipeline, which will then trigger the `run-tests` Tekton pipeline. The `run-tests` will fail as the CPS properties have not yet been upgraded to the new development version - this is okay.
 
 
 3. Upgrade CLI
@@ -40,15 +37,15 @@ These are manual steps to bump the version of Galasa to the next version.
 
     f. Merge in the PR and wait for the Main build to pass and finish
 
-    g. When the isolated Main build is triggered, cancel it with `kubectl delete pipelinerun -n galasa-build trigger-isolated-main-xxxx` replacing the correct pipeline run name.
+    g. When the Isolated Main build is triggered, cancel it on the GitHub UI [here](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) with the "Cancel Workflow" button, as you are going to rebuild it in the next step anyway.
 
 4. Upgrade Isolated
 
     a. Create branch
 
-    b. Invoke the `set-version --version {new version}` script.
+    b. Invoke the `set-version --version {new version}` script. Currently not all versions are found by the script alone, so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded.
 
-    c. Make sure it builds with `build-locally.sh`
+    c. There is no `build-locally.sh` script for this repo so you will have to rely on the GitHub Actions workflow to confirm it builds okay.
     
     d. Push
 
@@ -59,6 +56,36 @@ These are manual steps to bump the version of Galasa to the next version.
     a. Create branch
 
     b. Invoke the `set-version --version {new version}` script.
+    
+    c. Push
+
+    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+
+6. Upgrade Simplatform
+
+    a. Create branch
+
+    b. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded then run `build-locally.sh` to check it builds.
+    
+    c. Push
+
+    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+
+7. Upgrade Web UI
+
+    a. Create branch
+
+    b. Invoke the `set-version --version {new version}` script.
+    
+    c. Push
+
+    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+
+8. Upgrade Integratedtests (not a released component)
+
+    a. Create branch
+
+    b. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded then run `build-locally.sh` to check it builds.
     
     c. Push
 

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -46,3 +46,8 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
 10. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - Each maven artifact should contain a file called com.auth0.jwt-<*VERSION*>.jar.asc. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 11. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino or Will Yates to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+12. Test the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline:
+    - https://galasa.dev/docs/cli-command-reference/zipped-prerequisites
+    - https://galasa.dev/docs/cli-command-reference/installing-offline
+    - https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline
+    - https://galasa.dev/docs/running-simbank-tests/running-simbank-tests-cli-offline

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -37,8 +37,10 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
     - Branch: `pre-release`
     - Enable Jacoco code coverage: `false`
     - Artifacts should be signed: `true`
-8. Build the CLI and Isolated repositories that are not included in the mono repo. The CLI build which will trigger the Isolated build down the chain. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/cli/actions/workflows/build.yml) and select the following inputs:
-    - Branch: `pre-release`
+8. The build of the CLI repository and Isolated repository will be triggered automatically as part of the build chain, so monitor those builds and make sure they finish successfully. 
+    - The [CLI Main build workflow](https://github.com/galasa-dev/cli/actions/workflows/build.yml) should run with the `prerelease` ref
+    - This will trigger the Tekton pipeline `test-cli-ecosystem-commands` so go to the Tekton dashboard
+    - That will then trigger the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
 9. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `pre-release`
 10. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -37,8 +37,10 @@ For each of the Kubernetes Tekton command, you can follow with tkn -n galasa-bui
     - Branch: `release`
     - Enable Jacoco code coverage: `false`
     - Artifacts should be signed: `true`
-2. Build the CLI and Isolated repositories that are not included in the mono repo. The CLI build which will trigger the Isolated build down the chain. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/cli/actions/workflows/build.yml) and select the following inputs:
-    - Branch: `release`
+2. The build of the CLI repository and Isolated repository will be triggered automatically as part of the build chain, so monitor those builds and make sure they finish successfully. 
+    - The [CLI Main build workflow](https://github.com/galasa-dev/cli/actions/workflows/build.yml) should run with the `release` ref
+    - This will trigger the Tekton pipeline `test-cli-ecosystem-commands` so go to the Tekton dashboard
+    - That will then trigger the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `release` ref back in GitHub
 3. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `release`
 4. Run [28-run-regression-tests.sh](./28-run-regression-tests.sh). All the tests must pass before moving on. For the ones which fail, run them individually:
@@ -106,12 +108,6 @@ Once an approver has approved, you can move on.
 
    7. `exit` the image. -->
    <!-- End of temporary steps -->
-
-**IMPORTANT if releasing a Galasa wrapper:** This step uses the release version number to identify artefacts that have been updated in this release. However, the Galasa wrappers for OSGi bundles do not share the version naming conventions with the rest of the Galasa components, so won't get picked up in this. If a Galasa wrapper has been updated and needs to be released:
-
-   a. Amend line 87 of the 30-deploy-maven-galasa.sh script to say `galasa_version="<VERSION OF WRAPPER>"`. So if you are wanting to release jta version 1.2: `galasa_version="1.2"`.
-   b. Run the script as normal and check in the output on Tekton that only 1 artefact has been found and it is the expected one.
-   c. The next step will have to be done multiple times for each staging repository: the one with most of the components, and the other(s) for the wrapper(s).
 
 2. 31-oss-sonatype-actions.md - Do the Sonatype actions detailed in this document, to check the maven artifacts are OK, and release them to maven central.
 3. 32-wait-maven.sh - Run the watch command to wait for the artifacts to reach Maven Central. The release will appear in the BOM metadata. Wait until Maven Central is updated. Takes a while. 20 to 40-ish mins. Kill the terminal to exit this process.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -52,6 +52,11 @@ For each of the Kubernetes Tekton command, you can follow with tkn -n galasa-bui
    c. Run `kubectl apply -f argocd-synced/pipelines/regression-reruns.yaml` and `kubectl -n galasa-build create -f 29-regression-reruns.yaml` - Retest the failing tests.
 
    d. Repeat as required.
+5. Test the [mvp image](https://development.galasa.dev/release/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline:
+    - https://galasa.dev/docs/cli-command-reference/zipped-prerequisites
+    - https://galasa.dev/docs/cli-command-reference/installing-offline
+    - https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline
+    - https://galasa.dev/docs/running-simbank-tests/running-simbank-tests-cli-offline
 
 ### MEND scan (if releasing Distribution for Galasa)
 


### PR DESCRIPTION
## Why?

Improvements made for the 0.39.0 release and beyond following the 0.38.0 release.

- Create and delete `release-bld` or `prerelease-bld` ArgoCD app for galasabld executables, as buildutils is now part of the mono repo process, it attempts to recycle this app as part of the Release build. During the 0.38.0 release, the Release build failed as the app didn't exist.
- Adapt script to check the artifacts have been signed to check an artifact from each of the Galasa modules to check for the presence of `.pom.asc` files. This assumes that if signing is present for one artifact in the module, it will be for all others, as either none or all are signed.
- Update instructions to move to new development version to include all repos we are upgrading, and ensure to manually update all versions not found by the script.
- General updates to prerelease and release instructions.