### PR TITLE
Iss2007 - Recycle prod1 after changes to Web UI

### DIFF
--- a/pipelines/event-listeners/ingress.yaml
+++ b/pipelines/event-listeners/ingress.yaml
@@ -52,10 +52,10 @@ spec:
       paths:
       - backend:
           service:
-            name: el-github-obr-workflow-completed-listener
+            name: el-github-webui-workflow-completed-listener
             port:
               number: 8080
-        path: /obr-workflow
+        path: /webui-workflow
         pathType: Prefix
   - host: triggers.galasa.dev
     http:

--- a/pipelines/event-listeners/webui-workflow-completed.yaml
+++ b/pipelines/event-listeners/webui-workflow-completed.yaml
@@ -7,7 +7,7 @@
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: github-obr-workflow-completed-listener
+  name: github-webui-workflow-completed-listener
   annotations:
     tekton.dev/payload-validation: "false"
 spec:
@@ -33,12 +33,12 @@ spec:
           params:
           - name: "filter"
             value: "body.workflow_run.conclusion in ['success']"
-        - name: "CEL filter: only when the workflow was for the OBR repository"
+        - name: "CEL filter: only when the workflow was for the webui repository"
           ref:
             name: "cel"
           params:
           - name: "filter"
-            value: "body.repository.name in ['obr']"
+            value: "body.repository.name in ['webui']"
         - name: "CEL filter: only when the workflow branch was 'main'"
           ref:
             name: "cel"
@@ -57,33 +57,6 @@ spec:
                 pipelineRef:
                   name: recycle-prod1
                 serviceAccountName: galasa-build-bot
-                workspaces:
-                - name: git-workspace
-                  volumeClaimTemplate:
-                    spec:
-                      storageClassName: longhorn-temp
-                      accessModes:
-                        - ReadWriteOnce
-                      resources:
-                        requests:
-                          storage: 20Gi
-
-            - apiVersion: tekton.dev/v1beta1
-              kind: PipelineRun
-              metadata:
-                generateName: build-internal-integratedtests-
-              spec:
-                pipelineRef:
-                  name: build-internal-integratedtests
-                serviceAccountName: galasa-build-bot
-                podTemplate:
-                  volumes:
-                  - name: gradle-properties
-                    secret:
-                      secretName: gradle-properties
-                  - name: gpg-key
-                    secret:
-                      secretName: gpg-key
                 workspaces:
                 - name: git-workspace
                   volumeClaimTemplate:


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2007
- After the Web UI main build has finished successfully, recycle-prod1 should be called to deploy the changes to the prod1 service - EventListener created to do this.
- Add the new EventListener to the triggers Ingress list.
- Delete the obr-workflow-completed-listener as the OBR repository has now been archived.