### PR TITLE
Iss2089 - Create new download site for Java archives

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/java-archive/Chart.yaml
+++ b/infrastructure/cicsk8s/galasa-build/java-archive/Chart.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: galasa-java-archive
+description: Configuration for an interanl OpenJDK download site
+type: application
+version: 0.1.0
+appVersion: "0.20.0"

--- a/infrastructure/cicsk8s/galasa-build/java-archive/templates/deployment.yaml
+++ b/infrastructure/cicsk8s/galasa-build/java-archive/templates/deployment.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java-archive
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: java-archive
+  template:
+    metadata:
+      labels:
+        app: java-archive
+      name: java-archive
+    spec:
+      containers:
+      - env:
+          - name: CONTEXTROOT
+            value: {{ .Values.branch }}/java-archive
+        image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+        imagePullPolicy: Always
+        name: java-archive
+        ports:
+        - containerPort: 80
+

--- a/infrastructure/cicsk8s/galasa-build/java-archive/templates/ingress.yaml
+++ b/infrastructure/cicsk8s/galasa-build/java-archive/templates/ingress.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: java-archive
+  namespace: {{ .Values.namespace }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.externalHostname }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: java-archive
+                port:
+                  number: 80
+            path: /{{ .Values.branch }}/java-archive
+            pathType: Prefix

--- a/infrastructure/cicsk8s/galasa-build/java-archive/templates/service.yaml
+++ b/infrastructure/cicsk8s/galasa-build/java-archive/templates/service.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: java-archive
+  name: java-archive
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: java-archive

--- a/infrastructure/cicsk8s/galasa-build/java-archive/values.yaml
+++ b/infrastructure/cicsk8s/galasa-build/java-archive/values.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# These values are overridden in the ArgoCD app.
+
+namespace: galasa-build
+branch: main
+imageName: ghcr.io/galasa-dev/base-image
+imageTag: latest
+
+ingress:
+  externalHostname: development.galasa.dev
+  ingressClassName: public-iks-k8s-nginx
+  tls:
+  - hosts:
+      - development.galasa.dev
+    secretName: galasa-wildcard-cert


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2089

The values will be overridden and set in the ArgoCD app to protect the internal host name for this site.