### PR TITLE
Updates to CPS props and release process following 0.39.0 release

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -14,7 +14,7 @@ metadata:
     namespace: framework
     name: test.stream.inttests.location
 data:
-    value: https://development.galasa.dev/main/maven-repo/inttests/dev/galasa/dev.galasa.inttests.obr/0.39.0/dev.galasa.inttests.obr-0.39.0-testcatalog.json
+    value: https://development.galasa.dev/main/maven-repo/inttests/dev/galasa/dev.galasa.inttests.obr/0.40.0/dev.galasa.inttests.obr-0.40.0-testcatalog.json
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -22,7 +22,7 @@ metadata:
     namespace: framework
     name: test.stream.inttests.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.inttests.obr/0.39.0/obr 
+    value: mvn:dev.galasa/dev.galasa.inttests.obr/0.40.0/obr 
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -110,7 +110,7 @@ metadata:
     namespace: framework
     name: test.stream.simbank.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.39.0/obr
+    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.40.0/obr
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -159,7 +159,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.full.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.39.0/galasa-isolated-0.39.0.zip
+    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.40.0/galasa-isolated-0.40.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -167,7 +167,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.mvp.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.39.0/galasa-isolated-mvp-0.39.0.zip
+    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.40.0/galasa-isolated-mvp-0.40.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -199,7 +199,7 @@ metadata:
     namespace: galasaecosystem
     name: galasaboot.version
 data:
-    value: 0.39.0
+    value: 0.40.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -223,7 +223,7 @@ metadata:
     namespace: galasaecosystem
     name: runtime.version
 data:
-    value: 0.39.0
+    value: 0.40.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -231,7 +231,7 @@ metadata:
     namespace: galasaecosystem
     name: simbanktests.version
 data:
-    value: 0.39.0
+    value: 0.40.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -247,4 +247,4 @@ metadata:
     namespace: galasaecosystem
     name: simplatform.version
 data:
-    value: 0.39.0
+    value: 0.40.0

--- a/releasePipeline/95-move-to-new-version.md
+++ b/releasePipeline/95-move-to-new-version.md
@@ -2,91 +2,66 @@
 
 These are manual steps to bump the version of Galasa to the next version.
 
-1. Create a new branch in all of the repositories below called something like 'version-bump', don't call it 'release'
+1. Create a new branch in all of the repositories below called something like 'version-bump' (don't call it 'release').
 
-2. Upgrade the Galasa Monorepo
+2. Upgrade [Galasa](https://github.com/galasa-dev/galasa)
 
-    a. Create branch
+    a. Invoke the `./tools/set-version --version {new version}` script in which invokes a separate `set-version.sh` for each module.
 
-    b. Invoke the `./tools/set-version --version {new version}` script in which invokes a separate `set-version.sh` for each module.
+    b. Run the `./tools/build-locally.sh`, which will invoke each individual module's `build-locally.sh` script, which will update the versions in the generated `release.yaml`s.
 
-    c. Currently not all versions are found by the script alone such as dev.galasa.platform's version used throughout the code, so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded.
+    c. Manually check that all dev.galasa bundles have been upgraded. Do a search for the current version in VSCode to check for any versions that did not get uplifted by the script, and replace with the new development version.
 
-    d. Make sure it builds with `./tools/build-locally.sh` which will invoke each individual module's `build-locally.sh` script. Make sure the API Server starts locally also.
+    d. Make sure the API Server starts locally.
 
-    e. Push the changes to your branch
+    e. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-    f. Open PR for this change and wait for the PR build to pass
+    **Note:** Once the Galasa mono repo's build finishes, this will trigger the `recycle-prod1` Tekton pipeline, which will then trigger the `run-tests` Tekton pipeline. The `run-tests` will fail as the CPS properties have not yet been upgraded to the new development version (unless you have already done it with galasactl) - this is okay.
 
-    g. Merge in the PR and wait for the Main build to pass and finish
+3. Upgrade [Helm](https://github.com/galasa-dev/helm)
 
-    **Note:** Once the Galasa mono repo's build finishes, this will trigger the `recycle-prod1` Tekton pipeline, which will then trigger the `run-tests` Tekton pipeline. The `run-tests` will fail as the CPS properties have not yet been upgraded to the new development version - this is okay.
-
-
-3. Upgrade CLI
-
-    a. Create branch
-
-    b. Invoke the `set-version --version {new version}` script.
-
-    c. Make sure it builds with `build-locally.sh`
+    a. Invoke the `set-version --version {new version}` script.
     
-    d. Push
+    b. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-    e. Open PR for this change and wait for the PR build to pass
+4. Upgrade [Simplatform](https://github.com/galasa-dev/simplatform)
 
-    f. Merge in the PR and wait for the Main build to pass and finish
-
-    g. When the Isolated Main build is triggered, cancel it on the GitHub UI [here](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) with the "Cancel Workflow" button, as you are going to rebuild it in the next step anyway.
-
-4. Upgrade Isolated
-
-    a. Create branch
-
-    b. Invoke the `set-version --version {new version}` script. Currently not all versions are found by the script alone, so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded.
-
-    c. There is no `build-locally.sh` script for this repo so you will have to rely on the GitHub Actions workflow to confirm it builds okay.
+    a. Invoke the `set-version --version {new version}` script. **Note:** This will fail if the Galasa OBR has not been fully rebuilt and redeployed yet to the development.galasa.dev site, as the `set-version.sh` script uses `mvn` to uplift the versions, which will look for Simplatform's dependencies at the new version in Maven Central then the development.galasa.dev site.
     
-    d. Push
+    b. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+5. Upgrade [Web UI](https://github.com/galasa-dev/webui)
 
-5. Upgrade Helm charts
-
-    a. Create branch
-
-    b. Invoke the `set-version --version {new version}` script.
+    a. Invoke the `set-version --version {new version}` script.
     
-    c. Push
+    b. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+6. Upgrade [Integratedtests](https://github.com/galasa-dev/integratedtests) (not a released component)
 
-6. Upgrade Simplatform
-
-    a. Create branch
-
-    b. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded then run `build-locally.sh` to check it builds.
+    a. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded then run `build-locally.sh` to check it builds.
     
-    c. Push
+    b. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+7. Upgrade the [internal integrated tests](https://github.ibm.com/galasa/internal-integratedtests) (not a released component)
 
-7. Upgrade Web UI
-
-    a. Create branch
-
-    b. Invoke the `set-version --version {new version}` script.
+    a. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version.
     
-    c. Push
+    b. Push the changes to your branch, open a PR, then merge in the PR, and wait for the Main build to pass and finish.
 
-    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+8. Upgrade [CLI](https://github.com/galasa-dev/cli)
 
-8. Upgrade Integratedtests (not a released component)
+    a. Invoke the `set-version --version {new version}` script.
 
-    a. Create branch
+    b. Make sure it builds with `build-locally.sh`. This will also uplift the version in the generated docs files.
 
-    b. Currently no `set-version.sh` script exists so do a search for the current version in VSCode and replace with the new development version. Manually check that all dev.galasa bundles have been upgraded then run `build-locally.sh` to check it builds.
+    c. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+
+    d. When the Isolated Main build is triggered, cancel it on the GitHub UI [here](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) with the "Cancel Workflow" button, as you are going to rebuild it in the next step anyway.
+
+9. Upgrade [Isolated](https://github.com/galasa-dev/isolated)
+
+    a. Invoke the `set-version --version {new version}` script.
+
+    b. Make sure it builds with the `build-locally.sh`.
     
-    c. Push
-
-    e. Open PR for this change, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
+    c. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.

--- a/releasePipeline/argocd-synced/pipelines/deploy-maven-galasa.yaml
+++ b/releasePipeline/argocd-synced/pipelines/deploy-maven-galasa.yaml
@@ -44,6 +44,6 @@ spec:
       - --credentials
       - /mavencreds/mavencreds.yaml
     - name: image
-      value: ghcr.io/galasa-dev/obr-and-galasabld-executable
+      value: ghcr.io/galasa-dev/obr-with-galasabld-executable
     - name: galasabldImageTag
       value: release

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -44,10 +44,17 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
 9. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `pre-release`
 10. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
-    - Each maven artifact should contain a file called com.auth0.jwt-<*VERSION*>.jar.asc. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
-11. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino or Will Yates to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
-12. Test the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline:
-    - https://galasa.dev/docs/cli-command-reference/zipped-prerequisites
+    - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
+11. Send the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+12. Test the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline (although you will need to slightly adapt in some places as you are testing the MVP from the prerelease maven repo - these differences are documented below):
     - https://galasa.dev/docs/cli-command-reference/installing-offline
+        - 1: The output of `docker load -i isolated.tar` should instead be `Loaded image: ghcr.io/galasa-dev/galasa-mvp:main`.
+        - 2: Run the container by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:main` instead.
     - https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline
+        - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed).
     - https://galasa.dev/docs/running-simbank-tests/running-simbank-tests-cli-offline
+        - To run the Simbank tests using the galasactl binary and using only the Maven artifacts provided within the zip, you can run the below commands from the top level of the zip:
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.ProvisionedAccountCreditTests`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BatchAccountsOpenTest`

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -43,20 +43,29 @@ For each of the Kubernetes Tekton command, you can follow with tkn -n galasa-bui
     - That will then trigger the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `release` ref back in GitHub
 3. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `release`
-4. Run [28-run-regression-tests.sh](./28-run-regression-tests.sh). All the tests must pass before moving on. For the ones which fail, run them individually:
+4. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`release`' option.
+    - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
+5. Run [28-run-regression-tests.sh](./28-run-regression-tests.sh). All the tests must pass before moving on. For the ones which fail, run them individually:
 
    a. As currently some tests pass if run a second time due to the vaguaries of system resource availability. Also make sure @hobbit1983's VM image isn't down.
 
-   b. If there are any failures from the regression testing - Amend 29-regression-reruns.yaml to supply the correct version and argocd-synced/pipelines/regression-reruns.yaml. Add the tests that failed as shown in the example, to run them again.
+   b. If there are any failures from the regression testing, amend 29-regression-reruns.yaml to supply the correct version and argocd-synced/pipelines/regression-reruns.yaml. Add the tests that failed as shown in the example, to run them again.
 
    c. Run `kubectl apply -f argocd-synced/pipelines/regression-reruns.yaml` and `kubectl -n galasa-build create -f 29-regression-reruns.yaml` - Retest the failing tests.
 
    d. Repeat as required.
-5. Test the [mvp image](https://development.galasa.dev/release/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline:
-    - https://galasa.dev/docs/cli-command-reference/zipped-prerequisites
+6. Test the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline (although you will need to slightly adapt in some places as you are testing the MVP from the prerelease maven repo - these differences are documented below):
     - https://galasa.dev/docs/cli-command-reference/installing-offline
+        - 1: The output of `docker load -i isolated.tar` should instead be `Loaded image: ghcr.io/galasa-dev/galasa-mvp:main`.
+        - 2: Run the container by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:main` instead.
     - https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline
+        - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed)
     - https://galasa.dev/docs/running-simbank-tests/running-simbank-tests-cli-offline
+        - To run the Simbank tests using the galasactl binary and using only the Maven artifacts provided within the zip, you can run the below commands from the top level of the zip:
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.SimBankIVT`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BasicAccountCreditTest`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.ProvisionedAccountCreditTests`
+            - `./galasactl/galasactl runs submit local --log - --obr mvn:dev.galasa/dev.galasa.simbank.obr/<VERSION>/obr --localMaven file:////Users/<YOURUSER>/Downloads/galasa-isolated-mvp-<VERSION>/maven --class dev.galasa.simbank.tests/dev.galasa.simbank.tests.BatchAccountsOpenTest`
 
 ### MEND scan (if releasing Distribution for Galasa)
 
@@ -145,17 +154,35 @@ The pipeline it kicks off is called `tag-galasa-*`. Takes about a minute to comp
 2. 97-update-homebrew.md - Follow the manual steps in this file to make the new version of the CLI available for the homebrew installer.
 3. In the file `../infrastructure/cicsk8s/galasa-dev/cps-properties.yaml` update the CPS properties to contain the new development version number:
    
-   a. galasaecosystem.runtime.version (the property will have been updated manually as part of the last step, but we need to update the record here)
+   a. galasaecosystem.runtime.version
    
    b. galasaecosystem.isolated.full.zip
 
    c. galasaecosystem.isolated.mvp.zip
 
+   d. galasaecosystem.galasaboot.version
+
+   e. galasaecosystem.simbanktests.version
+
+   f. galasaecosystem.simplatform.version
+
+   g. framework.test.stream.inttests.location
+
+   h. framework.test.stream.inttests.obr
+
+   i. framework.test.stream.simbank.obr
+
    Deliver the changes to the automation repository and the CPS properties will be applied automatically.
 
 4. If the above fails and you need to update the CPS properties manually for some reason, run the `99-update-development-version.sh` script.
 
-5. Upgrade the version of the CLI we use for our regression testing to this released version. Retag the 'release' image of galasactl-ibm-x86_64 to 'stable' (regression testing uses galasactl-ibm-x86_64:stable):
+5. Update the CPS properties for the internal integrated tests using galasactl:
+
+   a. framework.test.stream.internal-inttests.location
+
+   b. framework.test.stream.internal-inttests.obr
+
+6. Upgrade the version of the CLI we use for our regression testing to this released version. Retag the 'release' image of galasactl-ibm-x86_64 to 'stable' (regression testing uses galasactl-ibm-x86_64:stable):
 
 ``` shell
 docker pull ghcr.io/galasa-dev/galasactl-ibm-x86_64:release


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2079

- Updating the galasa-prod1 CPS properties (already updated manually, but this file is reapplied on every build of this repo).
- Update the instructions to move development versions based on the state of the set-version scripts now. Also moved CLI and Isolated to end of this as other repos that come first in the build chain (Helm, Simplatform, Web UI) make more sense to upgrade first.
- Fix image tag used in deploy-maven-galasa Pipeline, it was incorrect.
- Update prerelease and release instructions with more detail on how to test the contents of the MVP zip.
- Update the release instructions with missing CPS properties to be upgraded each release, as we are now uplifting the version of everything.