### PR TITLE
Iss2085 - Update workflows to support/block forks

### DIFF
--- a/.github/workflows/base-image.yaml
+++ b/.github/workflows/base-image.yaml
@@ -5,16 +5,29 @@
 #
 name: Build Galasa httpd base image
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  NAMESPACE: galasa-dev
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
 
 jobs:
+  check-required-secrets-configured:
+    name: Check required secrets configured
+    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
+    with:
+      check_write_github_packages_username: 'true'
+      check_write_github_packages_token: 'true'
+    secrets:
+      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+
   build-base-image:
     name: Build the base httpd image for hosting the development Maven registries
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
@@ -22,14 +35,17 @@ jobs:
 
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Extract metadata for base image
         id: metadata
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/base-image
           tags: |
@@ -45,10 +61,11 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   report-failure:
+    # Skip this job for forks
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: build-base-image
-    if: failure()
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build-automation.yaml
+++ b/.github/workflows/build-automation.yaml
@@ -6,54 +6,57 @@
 name: Build custom images for automation
 
 on:
-  pull_request:
-    branches: 
-      - 'main'
   push:
     branches: 
       - 'main'
 
 env:
   REGISTRY: ghcr.io
-  NAMESPACE: galasa-dev
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
 
 jobs:
+  check-required-secrets-configured:
+    name: Check required secrets configured
+    uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
+    with:
+      check_write_github_packages_username: 'true'
+      check_write_github_packages_token: 'true'
+    secrets:
+      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+
   build-gpg-image:
     name: Build the 'gpg' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/gpg
 
-      - name: Build 'gpg' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/gpg-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'gpg' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/gpg-dockerfile
@@ -64,39 +67,34 @@ jobs:
   build-kubectl-image:
     name: Build the 'kubectl' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/kubectl
 
-      - name: Build 'kubectl' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/kubectl-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'kubectl' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/kubectl-dockerfile
@@ -107,39 +105,34 @@ jobs:
   build-argocdcli-image:
     name: Build the 'argocdcli' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/argocdcli
 
-      - name: Build 'argocdcli' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/argocd-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'argocdcli' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/argocd-dockerfile
@@ -150,39 +143,34 @@ jobs:
   build-gitcli-image:
     name: Build the 'gitcli' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/gitcli
 
-      - name: Build 'gitcli' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/gitcli-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'gitcli' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/gitcli-dockerfile
@@ -193,39 +181,34 @@ jobs:
   build-openapi-image:
     name: Build the 'openapi' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openapi
 
-      - name: Build 'openapi' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/openapi-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'openapi' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/openapi-dockerfile
@@ -236,39 +219,34 @@ jobs:
   build-swagger-image:
     name: Build the 'swagger' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/swagger
 
-      - name: Build 'swagger' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/common
-          file: dockerfiles/common/swagger-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'swagger' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/common
           file: dockerfiles/common/swagger-dockerfile
@@ -279,39 +257,35 @@ jobs:
   build-openjdk17-ibm-gradle-image:
     name: Build the 'openjdk17-ibm-gradle' image
     runs-on: ubuntu-latest
+    needs: check-required-secrets-configured
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+          sparse-checkout: |
+            dockerfiles/certs
+            dockerfiles/common
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openjdk17-ibm-gradle
 
-      - name: Build 'openjdk17-ibm-gradle' Docker image
-        if: github.event.pull_request.base.ref == 'main'
-        id: build
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - name: Log in to the GitHub Container registry
+        uses: docker/login-action@v3
+        env: 
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
         with:
-          context: dockerfiles/certs
-          file: dockerfiles/common/openjdk17-ibm-gradle-dockerfile
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Build and push 'openjdk17-ibm-gradle' Docker image
-        if: github.ref == 'refs/heads/main'
         id: build-push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v5
         with:
           context: dockerfiles/certs
           file: dockerfiles/common/openjdk17-ibm-gradle-dockerfile
@@ -320,10 +294,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   report-failure:
+    # Skip this job for forks
+    if: ${{ failure() && github.event_name == 'push' && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: [build-gpg-image, build-kubectl-image, build-argocdcli-image, build-gitcli-image, build-openapi-image, build-swagger-image, build-openjdk17-ibm-gradle-image]
-    if: failure()
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build-helm.yaml
+++ b/.github/workflows/build-helm.yaml
@@ -10,9 +10,12 @@ on:
 
 env:
   NAMESPACE: galasa-dev
+  BRANCH: ${{ github.ref_name }}
 
 jobs:
   build-helm:
+    # Skip this job for forks
+    if: ${{ github.repository_owner == 'galasa-dev' }}
     name: Build Helm chart for ecosystem1
     runs-on: ubuntu-latest
 
@@ -33,9 +36,11 @@ jobs:
         id: install
       
       - name: Setup kubeconfig secret
+        env: 
+          KUBE_CONFIG_PLAN_B_CLUSTER: ${{ secrets.KUBE_CONFIG_PLAN_B_CLUSTER }}
         run: |
           mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBE_CONFIG_PLAN_B_CLUSTER }}" >> $HOME/.kube/config
+          echo "${{ env.KUBE_CONFIG_PLAN_B_CLUSTER }}" >> $HOME/.kube/config
       
       - name: Uninstall ecosystem1
         run: |
@@ -50,10 +55,11 @@ jobs:
           helm test main-ecosystem --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
 
   report-failure:
+    # Skip this job for forks
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: build-helm
-    if: failure()
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/pr-build-automation.yaml
+++ b/.github/workflows/pr-build-automation.yaml
@@ -1,0 +1,206 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Build custom images for automation
+
+on:
+  pull_request:
+    branches: 
+      - 'main'
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  build-gpg-image:
+    name: Build the 'gpg' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/gpg
+
+      - name: Build 'gpg' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/gpg-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-kubectl-image:
+    name: Build the 'kubectl' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/kubectl
+
+      - name: Build 'kubectl' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/kubectl-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-argocdcli-image:
+    name: Build the 'argocdcli' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/argocdcli
+
+      - name: Build 'argocdcli' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/argocd-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-gitcli-image:
+    name: Build the 'gitcli' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/gitcli
+
+      - name: Build 'gitcli' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/gitcli-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-openapi-image:
+    name: Build the 'openapi' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openapi
+
+      - name: Build 'openapi' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/openapi-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+  
+  build-swagger-image:
+    name: Build the 'swagger' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/swagger
+
+      - name: Build 'swagger' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/common
+          file: dockerfiles/common/swagger-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-openjdk17-ibm-gradle-image:
+    name: Build the 'openjdk17-ibm-gradle' image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            dockerfiles/certs
+            dockerfiles/common
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openjdk17-ibm-gradle
+
+      - name: Build 'openjdk17-ibm-gradle' Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dockerfiles/certs
+          file: dockerfiles/common/openjdk17-ibm-gradle-dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2085

- Check the required secrets are configured in the repository before proceeding with the main build workflow, informs users of forks if they don't have the required secrets configured.
- Update use of docker/build-push-action and metadata-action to v5 instead of a commit sha
- Reference secrets from the `env` of steps instead of directly inside of steps as per best practice 
- Skip certain workflow jobs if the workflow is being run by a fork, to avoid failures for fork users
- Add `sparse-checkout` to the checkout step as all thats needed for these workflows is the contents of the `dockerfiles` directory
- Separate PR and main build workflow for automation, as one requires secrets and one does not