### PR TITLE
Iss2132 - Add new ArgoCD app to deploy IVTs to download site

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/Chart.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/Chart.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v2
+name: galasa-repositories
+description: The repositories for a Galasa build
+type: application
+version: 0.1.0
+appVersion: "0.20.0"

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/deployment.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/deployment.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ivts-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  revisionHistoryLimit: 1
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ivts-{{ .Values.branch }}
+  template:
+    metadata:
+      name: ivts-{{ .Values.branch }}
+      labels:
+        app: ivts-{{ .Values.branch }}
+    spec:
+      containers:
+        - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
+          imagePullPolicy: Always
+          name: ivts-{{ .Values.branch }}
+          env:
+          - name: CONTEXTROOT
+            value: {{ .Values.branch }}/maven-repo/{{ .Values.ingress.pathSuffix }}
+          ports:
+            - containerPort: 80

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/ingress.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ivts-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.externalHostname }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: ivts-{{ .Values.branch }}
+            port:
+              number: 80
+        path: /{{ .Values.branch }}/maven-repo/{{ .Values.ingress.pathSuffix }}
+        pathType: Prefix

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/service.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/templates/service.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ivts-{{ .Values.branch }}
+  name: ivts-{{ .Values.branch }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    - port: 80
+  selector:
+    app: ivts-{{ .Values.branch }}

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/values.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+namespace: galasa-development
+branch: main
+imageName: ghcr.io/jadecarino/ivts-maven-artefacts:main
+imageTag: main
+
+ingress:
+  externalHostname: development.galasa.dev
+  ingressClassName: public-iks-k8s-nginx
+  pathSuffix: ivts
+  annotations: {}
+  tls:
+  - hosts:
+      - development.galasa.dev
+    secretName: galasa-wildcard-cert


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2132

New ArgoCD app to deploy a maven repo to point the Galasa CPS properties at, containing the new IVTs.