### PR TITLE
Iss1888 - Replace refs to images in Harbor with GHCR

### DIFF
--- a/dockerfiles/base/base-dockerfile
+++ b/dockerfiles/base/base-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
+FROM ghcr.io/galasa-dev/httpd:alpine
 
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/dockerfiles/cli/cli-binary-dockerfile
+++ b/dockerfiles/cli/cli-binary-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:2.4.59
+FROM ghcr.io/galasa-dev/httpd:2.4.59
 RUN rm -v /usr/local/apache2/htdocs/*
 COPY automation/dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf
 COPY cli/bin/galasactl* /usr/local/apache2/htdocs/

--- a/dockerfiles/cli/cli-dockerfile
+++ b/dockerfiles/cli/cli-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.5
+FROM ghcr.io/galasa-dev/alpine:3.18.5
 
 ARG platform
 

--- a/dockerfiles/common/argocd-dockerfile
+++ b/dockerfiles/common/argocd-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.4
+FROM ghcr.io/galasa-dev/alpine:3.18.4
 
 RUN apk --no-cache add curl
 

--- a/dockerfiles/common/ghstatus-dockerfile
+++ b/dockerfiles/common/ghstatus-dockerfile
@@ -1,3 +1,3 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.4
+FROM ghcr.io/galasa-dev/alpine:3.18.4
 COPY bin/ghstatus /go/bin/ghstatus
 ENTRYPOINT ["/go/bin/ghstatus"]

--- a/dockerfiles/common/ghverify-dockerfile
+++ b/dockerfiles/common/ghverify-dockerfile
@@ -1,3 +1,3 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.6
+FROM ghcr.io/galasa-dev/alpine:3.18.6
 COPY bin/ghverify /go/bin/ghverify
 ENTRYPOINT ["/go/bin/ghverify"]

--- a/dockerfiles/common/github-monitor-dockerfile
+++ b/dockerfiles/common/github-monitor-dockerfile
@@ -1,3 +1,3 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.4
+FROM ghcr.io/galasa-dev/alpine:3.18.4
 COPY bin/ghmonitor /go/bin/ghmonitor
 ENTRYPOINT ["/go/bin/ghmonitor"]

--- a/dockerfiles/common/github-receiver-dockerfile
+++ b/dockerfiles/common/github-receiver-dockerfile
@@ -1,3 +1,3 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.6
+FROM ghcr.io/galasa-dev/alpine:3.18.6
 COPY bin/ghreceiver /go/bin/ghreceiver
 ENTRYPOINT ["/go/bin/ghreceiver"]

--- a/dockerfiles/common/gpg-dockerfile
+++ b/dockerfiles/common/gpg-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/ubuntu:20.04
+FROM ghcr.io/galasa-dev/ubuntu:20.04
 
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 RUN apt-get update && apt-get install -y unzip \

--- a/dockerfiles/common/kubectl-dockerfile
+++ b/dockerfiles/common/kubectl-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.4
+FROM ghcr.io/galasa-dev/alpine:3.18.4
 
 RUN apk add curl
 

--- a/dockerfiles/common/openapi-dockerfile
+++ b/dockerfiles/common/openapi-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/openjdk:11
+FROM ghcr.io/galasa-dev/openjdk:11
 
 RUN mkdir /opt/openapi
 RUN curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.6.0/openapi-generator-cli-6.6.0.jar -o /opt/openapi/openapi-generator-cli.jar

--- a/dockerfiles/common/openjdk17-ibm-gradle-dockerfile
+++ b/dockerfiles/common/openjdk17-ibm-gradle-dockerfile
@@ -1,5 +1,5 @@
 
-FROM harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
+FROM ghcr.io/galasa-dev/gradle:8.9-jdk17
 
 COPY ibmroot.pem  /etc/ssl/certs/ibmroot.pem
 COPY ibminter.pem /etc/ssl/certs/ibminter.pem

--- a/dockerfiles/common/swagger-dockerfile
+++ b/dockerfiles/common/swagger-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/openjdk:11
+FROM ghcr.io/galasa-dev/openjdk:11
 
 RUN mkdir /opt/swagger
 RUN curl -L https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.41/swagger-codegen-cli-3.0.41.jar -o /opt/swagger/swagger-codegen-cli.jar

--- a/dockerfiles/common/tkn-dockerfile
+++ b/dockerfiles/common/tkn-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/alpine:3.18.6
+FROM ghcr.io/galasa-dev/alpine:3.18.6
 
 RUN apk add curl
 RUN apk add sudo

--- a/dockerfiles/release/resources/resources-dockerfile
+++ b/dockerfiles/release/resources/resources-dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.galasa.dev/docker_proxy_cache/library/httpd:alpine
+FROM ghcr.io/galasa-dev/httpd:alpine
 ARG branch
 ARG version
 

--- a/infrastructure/cicsk8s/galasa-dev/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/regression-test.yaml
@@ -26,7 +26,7 @@ spec:
             - -R
             - "777"
             - /galasa
-            image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+            image: ghcr.io/galasa-dev/busybox:1.36.1
             imagePullPolicy: IfNotPresent
             resources: {}
             terminationMessagePath: /dev/termination-log

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
@@ -43,7 +43,7 @@ spec:
                 - critical
       initContainers:
       - name: init-chown-data
-        image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.32.0
+        image: ghcr.io/galasa-dev/busybox:1.32.0
         imagePullPolicy: IfNotPresent
         command: ["chown", "-R", "1000", "/data"]
         volumeMounts:

--- a/pipelines/pipelines/cli/build-pr.yaml
+++ b/pipelines/pipelines/cli/build-pr.yaml
@@ -300,7 +300,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/bash:3.2.57
+      value: ghcr.io/galasa-dev/bash:3.2.57
     - name: command
       value: 
         - chmod

--- a/pipelines/pipelines/cli/test-cli-ecosystem-commands.yaml
+++ b/pipelines/pipelines/cli/test-cli-ecosystem-commands.yaml
@@ -48,7 +48,7 @@ spec:
     - name: context
       value: $(context.pipelineRun.name)/cli
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/bash:3.2.57
+      value: ghcr.io/galasa-dev/bash:3.2.57
     - name: command
       value: 
         - chmod

--- a/pipelines/pipelines/codecoverage/codecoverage.yaml
+++ b/pipelines/pipelines/codecoverage/codecoverage.yaml
@@ -303,7 +303,7 @@ spec:
               java -jar target/org.jacoco.cli.jar merge target/unittests/*.exec --destfile target/image/unit/jacoco.exec &&
               java -jar target/org.jacoco.cli.jar report target/image/unit/jacoco.exec --classfiles target/classes --sourcefiles target/sources --name 'Galasa CC Unit only' --html target/image/unit/ --xml target/image/unit/jacoco.xml
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/openjdk:11    
+      value: ghcr.io/galasa-dev/openjdk:11    
     workspaces:
     - name: git-workspace
       workspace: git-workspace    
@@ -321,7 +321,7 @@ spec:
               java -jar target/org.jacoco.cli.jar merge target/inttests/dev.galasa.inttests/*.exec --destfile target/image/integrated/jacoco.exec &&
               java -jar target/org.jacoco.cli.jar report target/image/integrated/jacoco.exec --classfiles target/classes --sourcefiles target/sources --name 'Galasa CC Integrated only' --html target/image/integrated/ --xml target/image/integrated/jacoco.xml
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/openjdk:11    
+      value: ghcr.io/galasa-dev/openjdk:11    
     workspaces:
     - name: git-workspace
       workspace: git-workspace 
@@ -339,7 +339,7 @@ spec:
               java -jar target/org.jacoco.cli.jar merge target/image/unit/jacoco.exec target/image/integrated/jacoco.exec --destfile target/image/combined/jacoco.exec &&
               java -jar target/org.jacoco.cli.jar report target/image/combined/jacoco.exec --classfiles target/classes --sourcefiles target/sources --name 'Galasa CC Combined' --html target/image/combined/ --xml target/image/combined/jacoco.xml
     - name: image
-      value: harbor.galasa.dev/docker_proxy_cache/library/openjdk:11    
+      value: ghcr.io/galasa-dev/openjdk:11    
     workspaces:
     - name: git-workspace
       workspace: git-workspace 
@@ -355,7 +355,7 @@ spec:
     - name: script
       value: cp -v /workspace/git/$(context.pipelineRun.name)/obr/codecoveragetemplates/* /workspace/git/$(context.pipelineRun.name)/target/
     # - name: image
-    #   value: harbor.galasa.dev/docker_proxy_cache/library/openjdk:11    
+    #   value: ghcr.io/galasa-dev/openjdk:11    
     workspaces:
     - name: git-workspace
       workspace: git-workspace     

--- a/pipelines/tasks/general-command.yaml
+++ b/pipelines/tasks/general-command.yaml
@@ -20,7 +20,7 @@ spec:
     type: array
   - name: image
     type: string  
-    default: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+    default: ghcr.io/galasa-dev/busybox:1.36.1
   steps:
   - name: run-command
     workingDir: /workspace/git/$(params.context)

--- a/pipelines/tasks/git-clean.yaml
+++ b/pipelines/tasks/git-clean.yaml
@@ -20,7 +20,7 @@ spec:
   steps:
   - name: clean-subdirectory
     workingDir: /workspace/git/
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+    image: ghcr.io/galasa-dev/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - rm

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -22,7 +22,7 @@ spec:
     type: array
   - name: image
     type: string
-    default: harbor.galasa.dev/docker_proxy_cache/library/gradle:8.9-jdk17
+    default: ghcr.io/galasa-dev/gradle:8.9-jdk17
   steps:
   - name: gradle-build
     workingDir: /workspace/git/$(params.context)

--- a/pipelines/tasks/make.yaml
+++ b/pipelines/tasks/make.yaml
@@ -23,7 +23,7 @@ spec:
   steps:
   - name: make
     workingDir: /workspace/git/$(params.directory)
-    image: harbor.galasa.dev/docker_proxy_cache/library/golang:1.20.1
+    image: ghcr.io/galasa-dev/golang:1.20.1
     imagePullPolicy: IfNotPresent
     command: 
       - make

--- a/pipelines/tasks/maven-build.yaml
+++ b/pipelines/tasks/maven-build.yaml
@@ -24,7 +24,7 @@ spec:
     type: array
   - name: image
     type: string
-    default: harbor.galasa.dev/docker_proxy_cache/library/maven:3.8.5-openjdk-17
+    default: ghcr.io/galasa-dev/maven:3.8.5-openjdk-17
   steps:
   - name: maven-build
     workingDir: /workspace/git/$(params.context)

--- a/pipelines/tasks/maven-gpg.yaml
+++ b/pipelines/tasks/maven-gpg.yaml
@@ -22,7 +22,7 @@ spec:
   steps:
   - name: gpgdirectory
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+    image: ghcr.io/galasa-dev/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - mkdir
@@ -54,7 +54,7 @@ spec:
       mountPath: /root/mavengpg
   - name: copy-settings
     workingDir: /workspace/git/$(params.context)
-    image: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+    image: ghcr.io/galasa-dev/busybox:1.36.1
     imagePullPolicy: IfNotPresent
     command:
     - cp

--- a/pipelines/tasks/script.yaml
+++ b/pipelines/tasks/script.yaml
@@ -20,7 +20,7 @@ spec:
     type: string
   - name: image
     type: string
-    default: harbor.galasa.dev/docker_proxy_cache/library/busybox:1.36.1
+    default: ghcr.io/galasa-dev/busybox:1.36.1
   steps:
   - name: script
     workingDir: /workspace/git/$(params.context)


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1888

Replacing references to images stored in Harbor with GHCR now they have been moved over to our "docker proxy cache". Harbor has been experiencing unexplained issues so pulling/pushing images there has been failing, and so PR builds have been failing sporadically all day. Moving our regularly used based images to GHCR removes the chance for these outages which affect our delivery.