### PR TITLE
Add more images to the docker proxy cache sync job

### DIFF
--- a/.github/workflows/sync-docker-proxy.yaml
+++ b/.github/workflows/sync-docker-proxy.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Pull, Retag, and Push Images
         run: |
-          IMAGES=("alpine:3.18.4" "alpine:3.18.5" "alpine:3.18.6" "bash:3.2.57" "busybox:1.32.0" "busybox:1.36.1" "golang:1.20.1" "gradle:8.9-jdk17" "httpd:alpine" "httpd:2.4.59" "maven:3.8.5-openjdk-17" "openjdk:11" "ubuntu:20.04")
+          IMAGES=("alpine:3.18.4" "alpine:3.18.5" "alpine:3.18.6" "bash:3.2.57" "busybox:1.32.0" "busybox:1.36.1" "golang:1.20.1" "gradle:8.9-jdk17" "httpd:alpine" "httpd:2.4.59" "maven:3.8.5-openjdk-17" "node:20.10.0-alpine" "openjdk:11" "openjdk:11-jdk" "openjdk:17" "ubuntu:20.04")
           for IMAGE in "${IMAGES[@]}"; do
             docker pull docker.io/library/$IMAGE
             docker tag docker.io/library/$IMAGE ghcr.io/${{ env.NAMESPACE }}/$IMAGE


### PR DESCRIPTION
## Why?

Add more images to our "docker proxy" - these are used in webui, simplatform, obr and isolated.