### PR TITLE
Fix github-webhook-receiver deployment

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-webhook-receiver/secret-github-token.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-webhook-receiver/secret-github-token.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:  
+  name: github-token
+  namespace: galasa-development
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: ibmcloud-secrets-manager
+    kind: SecretStore
+  target:
+    name: github-token
+    template:
+      type: Opaque
+
+  data:
+  - secretKey: token
+    # Corresponds to the secret: 'galasa-github-username-token' #pragma: allowlist secret 
+    remoteRef:
+      key: username_password/015c4542-82c9-6317-a6fe-4eda3d88c288
+      property: password


### PR DESCRIPTION
## Why?

Add github-token ExternalSecret for github-webhook-receiver to authenticate during the program execution.