### PR TITLE
Remove gpg key id value from files

### DIFF
--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gradle-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-gradle-properties.yaml
@@ -21,11 +21,16 @@ spec:
       engineVersion: v2
       data:
         gradle.properties: |
-          signing.keyId=221FFDC2
+          signing.keyId={{ .keyid }}
           signing.password={{ .password }}
           signing.secretKeyRingFile=/home/gradle/.gradle/galasa.gpg
         password: "{{ .password }}"
+        keyid: "{{ .keyid }}"
   data:
+  - secretKey: keyid
+    remoteRef:
+      key: galasa-secrets/gpg-keyid
+      property: keyid
   - secretKey: password
     remoteRef:
       key: galasa-secrets/gpg-passphrase

--- a/infrastructure/cicsk8s/galasa-build/external-secrets/secret-mavengpg.yaml
+++ b/infrastructure/cicsk8s/galasa-build/external-secrets/secret-mavengpg.yaml
@@ -34,9 +34,9 @@ spec:
                               <activeByDefault>true</activeByDefault>
                           </activation>
                 <properties>
-                  <gpg.keyname>662734DC2A745A00C08FACE175533914221FFDC2</gpg.keyname>
-                                          <gpg.passphrase>{{ .passphrase }}</gpg.passphrase>
-                                          <gpg.homedir>/workspace/git/gpg</gpg.homedir>
+                  <gpg.keyname>{{ .keyid }}</gpg.keyname>
+                  <gpg.passphrase>{{ .passphrase }}</gpg.passphrase>
+                  <gpg.homedir>/workspace/git/gpg</gpg.homedir>
                 </properties>
                       <repositories>
                           <repository>
@@ -67,6 +67,10 @@ spec:
     remoteRef:
       key: galasa-secrets/gpg
       property: payload
+  - secretKey: keyid
+    remoteRef:
+      key: galasa-secrets/gpg-keyid
+      property: keyid
   - secretKey: passphrase
     remoteRef:
       key: galasa-secrets/gpg-passphrase

--- a/pipelines/tasks/gradle-build.yaml
+++ b/pipelines/tasks/gradle-build.yaml
@@ -30,7 +30,11 @@ spec:
     imagePullPolicy: IfNotPresent
     env:
     - name: ORG_GRADLE_PROJECT_signingKeyId
-      value: 221FFDC2
+      valueFrom:
+        secretKeyRef:
+          name: gradle-properties
+          key: keyid
+          optional: false
     - name: ORG_GRADLE_PROJECT_signingKey
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
## Why?

GPG key ID has always been checked in but really should be hidden and stored in a secret