### PR TITLE
Update PR and PR Reviewed Event Listeners

### DIFF
--- a/pipelines/event-listeners/pr-builds.yaml
+++ b/pipelines/event-listeners/pr-builds.yaml
@@ -32,7 +32,7 @@ spec:
             name: "cel"
           params:
           - name: "filter"
-            value: "body.repository.name in ['automation','cli']"
+            value: "body.repository.name in ['githubapp-copyright']"
       bindings:
         - name: git-repository-name
           value: $(body.pull_request.head.repo.name)

--- a/pipelines/event-listeners/pr-reviewed-build.yaml
+++ b/pipelines/event-listeners/pr-reviewed-build.yaml
@@ -38,7 +38,7 @@ spec:
             name: "cel"
           params:
           - name: "filter"
-            value: "body.repository.name in ['automation','cli']"
+            value: "body.repository.name in ['githubapp-copyright']"
       bindings:
         - name: git-repository-name
           value: $(body.pull_request.head.repo.name)


### PR DESCRIPTION
## Why?

Update PR and PR Reviewed Event Listeners to filter on the githubapp-copyright repo, as thats the only remaining pipeline thats prefixed with `pr-`. Although its not in our build chain and is rarely used, still important to keep the EventListeners up to date for when we do go in to update this repo.

Prior to this change we were getting `PipelineNotFound` errors for `pr-automation` and `pr-cli` as they have been deleted.