### PR TITLE
Remove -x86_64 suffix from references to the boot-embedded images

### DIFF
--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/config.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/config.yaml
@@ -25,7 +25,7 @@ data:
 # The label for the engine pods and the prefix of the engine names
   engine_label: "k8s-standard-engine"
 #
-  engine_image: "ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main"
+  engine_image: "ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main"
   node_arch: "amd64"
 #  node_arch: ""
 #  node_preferred_affinity: "beta.kubernetes.io/arch=s390x"

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-api.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-api.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-engine-controller.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-engine-controller.yaml
@@ -28,7 +28,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-metrics.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-metrics.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: metrics
-        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-resource-monitor.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-resource-monitor.yaml
@@ -27,7 +27,7 @@ spec:
         applevel: critical
       containers:
       - name: resource-monitor
-        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
+++ b/infrastructure/cicsk8s/galasa-prod/galasa-prod/server-testcatalog.yaml
@@ -52,7 +52,7 @@ spec:
           subPath: ""
       containers:
       - name: resource-monitor
-        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded-x86_64:main
+        image: ghcr.io/galasa-dev/galasa-ibm-boot-embedded:main
         imagePullPolicy: Always
         command: ["java"]
         args: 

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -36,7 +36,7 @@ galasaRegistry: "ghcr.io/galasa-dev"
 # 
 # The name of the Docker image that contains Galasa's boot.jar file to launch ecosystem services
 #
-galasaBootImage: "galasa-boot-embedded-x86_64"
+galasaBootImage: "galasa-boot-embedded"
 #
 #
 # The name of the Docker image that launches Galasa's web UI

--- a/releasePipeline/34-deploy-docker-galasa.sh
+++ b/releasePipeline/34-deploy-docker-galasa.sh
@@ -98,48 +98,60 @@ run_command ibmcloud cr login
 
 run_command docker pull ghcr.io/galasa-dev/javadoc-site:$FROM
 run_command docker pull ghcr.io/galasa-dev/restapidoc-site:$FROM
-run_command docker pull ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
 run_command docker pull icr.io/galasadev/galasa-resources:$FROM
 run_command docker pull ghcr.io/galasa-dev/webui:$FROM
 
 
 
 
-run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM                  \
+run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM \
            icr.io/galasadev/galasa-javadoc-amd64:$TO
 
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:$TO
 
-run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM       \
-           icr.io/galasadev/galasa-boot-embedded-amd64:$TO
-
-run_command docker tag icr.io/galasadev/galasa-resources:$FROM       \
+run_command docker tag icr.io/galasadev/galasa-resources:$FROM \
            icr.io/galasadev/galasa-resources:$TO
 
-run_command docker tag ghcr.io/galasa-dev/webui:$FROM       \
+run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
            icr.io/galasadev/galasa-ui:$TO
 
-run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM                \
+run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM \
            icr.io/galasadev/galasa-javadoc-amd64:latest
 
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:latest
 
-run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM      \
-           icr.io/galasadev/galasa-boot-embedded-amd64:latest
-
-run_command docker tag icr.io/galasadev/galasa-resources:$FROM      \
+run_command docker tag icr.io/galasadev/galasa-resources:$FROM \
            icr.io/galasadev/galasa-resources:latest
 
-run_command docker tag ghcr.io/galasa-dev/webui:$FROM       \
+run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
            icr.io/galasadev/galasa-ui:latest
 
+# Pull and retag the galasa-boot-embedded images
+# linux/amd64
+run_command docker pull --platform linux/amd64 ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
+
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasadev/galasa-boot-embedded-amd64:$TO
+
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasadev/galasa-boot-embedded-amd64:latest
+
+# linux/arm64
+run_command docker pull --platform linux/arm64 ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
+
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasadev/galasa-boot-embedded-arm64:$TO
+
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
 
 run_command docker push icr.io/galasadev/galasa-javadoc-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-restapidoc-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:$TO
+run_command docker push icr.io/galasadev/galasa-boot-embedded-arm64:$TO
 run_command docker push icr.io/galasadev/galasa-resources:$TO
 run_command docker push icr.io/galasadev/galasa-ui:$TO
 
@@ -148,6 +160,7 @@ run_command docker push icr.io/galasadev/galasa-ui:$TO
 run_command docker push icr.io/galasadev/galasa-javadoc-amd64:latest
 run_command docker push icr.io/galasadev/galasa-restapidoc-amd64:latest
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:latest
+run_command docker push icr.io/galasadev/galasa-boot-embedded-arm64:latest
 run_command docker push icr.io/galasadev/galasa-resources:latest
 run_command docker push icr.io/galasadev/galasa-ui:latest
 

--- a/releasePipeline/34-deploy-docker-galasa.sh
+++ b/releasePipeline/34-deploy-docker-galasa.sh
@@ -98,7 +98,7 @@ run_command ibmcloud cr login
 
 run_command docker pull ghcr.io/galasa-dev/javadoc-site:$FROM
 run_command docker pull ghcr.io/galasa-dev/restapidoc-site:$FROM
-run_command docker pull ghcr.io/galasa-dev/galasa-boot-embedded-x86_64:$FROM
+run_command docker pull ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
 run_command docker pull icr.io/galasadev/galasa-resources:$FROM
 run_command docker pull ghcr.io/galasa-dev/webui:$FROM
 
@@ -111,7 +111,7 @@ run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM                  \
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:$TO
 
-run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded-x86_64:$FROM       \
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM       \
            icr.io/galasadev/galasa-boot-embedded-amd64:$TO
 
 run_command docker tag icr.io/galasadev/galasa-resources:$FROM       \
@@ -126,7 +126,7 @@ run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM                \
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:latest
 
-run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded-x86_64:$FROM      \
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM      \
            icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
 run_command docker tag icr.io/galasadev/galasa-resources:$FROM      \

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -198,8 +198,8 @@ docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
 2. (**Manual until we automate it with GitHub Actions**) Delete the images in GHCR tagged 'release':
    - obr-maven-artefacts
    - obr-generic
-   - galasa-boot-embedded-x86_64
-   - galasa-ibm-boot-embedded-x86_64
+   - galasa-boot-embedded
+   - galasa-ibm-boot-embedded
    - javadoc-maven-artefacts
    - javadoc-site
    - galasactl-x86_64


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2117

## Changes
- The `-x86_64` suffix has been removed from the boot-embedded images in https://github.com/galasa-dev/galasa/pull/197 now that they are built as multi-platform images, so this PR renames all references to remove that suffix