### PR TITLE
Fix location of galasa-resources image in Docker deploy script

### DIFF
--- a/releasePipeline/34-deploy-docker-galasa.sh
+++ b/releasePipeline/34-deploy-docker-galasa.sh
@@ -98,7 +98,7 @@ run_command ibmcloud cr login
 
 run_command docker pull ghcr.io/galasa-dev/javadoc-site:$FROM
 run_command docker pull ghcr.io/galasa-dev/restapidoc-site:$FROM
-run_command docker pull icr.io/galasadev/galasa-resources:$FROM
+run_command docker pull ghcr.io/galasa-dev/galasa-resources:$FROM
 run_command docker pull ghcr.io/galasa-dev/webui:$FROM
 
 
@@ -110,7 +110,7 @@ run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM \
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:$TO
 
-run_command docker tag icr.io/galasadev/galasa-resources:$FROM \
+run_command docker tag ghcr.io/galasa-dev/galasa-resources:$FROM \
            icr.io/galasadev/galasa-resources:$TO
 
 run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
@@ -122,7 +122,7 @@ run_command docker tag ghcr.io/galasa-dev/javadoc-site:$FROM \
 run_command docker tag ghcr.io/galasa-dev/restapidoc-site:$FROM \
            icr.io/galasadev/galasa-restapidoc-amd64:latest
 
-run_command docker tag icr.io/galasadev/galasa-resources:$FROM \
+run_command docker tag ghcr.io/galasa-dev/galasa-resources:$FROM \
            icr.io/galasadev/galasa-resources:latest
 
 run_command docker tag ghcr.io/galasa-dev/webui:$FROM \


### PR DESCRIPTION
## Why?

PR #651 edited the galasa-resources image location to be stored in GHCR instead of ICR. However PR #653 was missing the update for the docker deploy script to look at this new location. 