### PR TITLE
upgrade ecosystem1 to use memory limits

### DIFF
--- a/build-images/github-verify/cmd/main.go
+++ b/build-images/github-verify/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -48,8 +49,15 @@ func main() {
 	prUrl := flag.String("pr", "", "URL of the pr to verify")
 	org := flag.String("org", "", "which github org are we looking for users in")
 	approvedGroups := flag.String("approved-groups", "", "the github groups get auto-build on PRs")
-	action := flag.String("action", "", "what github action occured")
+	action := flag.String("action", "", "what github action occurred")
 	flag.Parse()
+
+	log.Printf("github-verify tool.\n")
+	log.Printf("UserId of the PR opener : %v\n", userId)
+	log.Printf("URL of the PR to verify : %v\n", prUrl)
+	log.Printf("Github organisation we are looking for the user in : %v\n", org)
+	log.Printf("Github github groups which get auto-build on PRs : %v\n", approvedGroups)
+	log.Printf("Which github action just occurred : %v\n", action)
 
 	// Get PR object
 	var pr types.Pull

--- a/infrastructure/dns/readme.md
+++ b/infrastructure/dns/readme.md
@@ -1,0 +1,36 @@
+# DNS
+
+The Linux Foundation owns the `galasa.dev` DNS domain on behalf of the Galasa project.
+
+
+
+
+These are the settings currently held in the DNS table currently.
+
+## Change history:
+- Ticket to set up the initial DNS records: https://jira.linuxfoundation.org/plugins/servlet/desk/portal/2/IT-27904
+
+## Current snapshot of the records we have configured:
+
+| Record Type | subdomain | target |
+|-------------|-----------|--------|
+| A | argocd.galasa.dev | | 169.50.192.70 |
+| A | argocd-b.galasa.dev | 169.50.192.70 |
+| A | copyright.galasa.dev | 169.50.192.70 |
+| A | development.galasa.dev | 169.50.192.70 |
+| A | dex.galasa.dev | 169.50.192.70 |
+| A | docker.galasa.dev | 169.50.192.70 |
+| A | galasa-ecosystem1.galasa.dev | 169.50.192.70 |
+| A | harbor.galasa.dev | 169.50.192.70 |
+| A | harbor-b.galasa.dev | 169.50.192.70 |
+| A | hobbit.galasa.dev | 169.50.192.70 |
+| A | javadoc.galasa.dev | 169.50.192.70 |
+| A | javadoc-snapshot.galasa.dev | 169.50.192.70 |
+| A | nexus.galasa.dev | 169.50.192.70 |
+| A | nexus-planb.galasa.dev | 169.50.192.70 |
+| A | resources.galasa.dev | 169.50.192.70 |
+| A | rest.galasa.dev | 169.50.192.70 |
+| A | sonarqube.galasa.dev | 169.50.192.70 |
+| A | triggers.galasa.dev | 169.50.192.70 |
+| A | www.galasa.dev | 192.0.2.1 |
+|CNAME | vnext.galasa.dev | custom.jdugayyprc6.eu-gb.codeengine.appdomain.cloud |

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -162,3 +162,247 @@ dex:
       refreshTokens:
         reuseInterval: 8760h # 1 year
         validIfNotUsedFor: 8760h # 1 year
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "400m"
+      memory: "300Mi"
+    limits:
+      cpu: "600m"
+      memory: "500Mi"
+
+
+#
+#
+# Values to configure the API server
+#
+apiServer:
+  #
+  #
+  # The number of API server replicas to deploy. This value is overridden when autoscaling is enabled.
+  #
+  replicaCount: 2
+  #
+  #
+  # The requests and limits to apply to resources, like CPU and memory, that the API server container consumes.
+  # See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for details on resource management in Kubernetes Pods.
+  #
+  # For example, to assign 2 CPU cores and 512MB of memory to the API server, with a limit of up to 3 CPU cores and 1024MB of memory:
+  # resources:
+  #   requests:
+  #     cpu: "2"
+  #     memory: "512Mi"
+  #   limits:
+  #     cpu: "3"
+  #     memory: "1024Mi"
+  #
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "500Mi"
+    limits:
+      cpu: "900m"
+      memory: "800Mi"
+
+  #
+  # Values to configure autoscaling for the API server. Important: Resource requests must be defined via the `resources` value in order
+  # for autoscaling to work properly.
+  #
+  autoscaling:
+    #
+    # Enables or disables autoscaling
+    enabled: true
+    #
+    # The minimum number of API server replicas that should be deployed
+    minReplicas: 1
+    #
+    # The maximum number of API server replicas that should be deployed
+    maxReplicas: 10
+    #
+    # The target percentage of CPU utilization to consider when autoscaling.
+    # For example: `targetCPU: "50"` indicates that the autoscaler may increase the number of replicas when CPU utilization
+    # exceeds 50%. Similarly, when CPU utilization drops below 50%, the autoscaler may decrease the number of replicas.
+    targetCPUPercentageUsed: "50"
+    #
+    # The target percentage of memory utilization to consider when autoscaling.
+    # For example: `targetMemory: "50"` indicates that the autoscaler may increase the number of replicas when memory utilization
+    # exceeds 50%. Similarly, when memory utilization drops below 50%, the autoscaler may decrease the number of replicas.
+    targetMemoryPercentageUsed: "50"
+
+  #
+  #
+  # The Kubernetes annotations to apply to the Galasa API server's ingress resource alongside the global annotations provided via the `ingress.annotations` value.
+  # By default, a rate limit of 1000 requests from a given IP per second is applied to the API server's ingress, using the nginx ingress controller.
+  #
+  ingressAnnotations:
+    nginx.ingress.kubernetes.io/limit-rps: "1000"
+  #
+  #
+  # A list of origins that are allowed to receive responses from the Galasa API server.
+  # To limit the origins to a set of domains, you can use a wildcard (*) value.
+  #
+  # For example, to allow all subdomains of example.com, you can use the following value:
+  # allowedOrigins:
+  #   - "*.example.com"
+  #
+  # By default, all origins are allowed.
+  #
+  allowedOrigins:
+    - "*"
+
+#
+# The values below allow the location of the ETCD stores, DSS, CREDS, and CPS,
+# to be configurable. There is a separate URL for each store as you may want to
+# use the default store location for CPS and CREDS, but not for DSS, for example.
+#
+# If using the defaults below, RELEASE_NAME is replaced with {{ .Release.Name }}
+# when used in templates. If you override these default values with your own store
+# location, you do not have to include the release name in your store's URL.
+#
+# The "etcd:" prefix is appended in the templates so it should not be included here.
+#
+dssUrl: http://RELEASE_NAME-etcd:2379
+credsUrl: http://RELEASE_NAME-etcd:2379
+cpsUrl: http://RELEASE_NAME-etcd:2379
+#
+#
+# cleanupMonitor represents the values required to configure a custom resource cleanup
+# monitor for use by the Galasa service, so that resources provisioned by managers that
+# are not publicly available in the Galasa open source offering can be cleaned up.
+#
+cleanupMonitor:
+  #
+  # The name of the stream in which custom resource cleanup providers can be located.
+  stream: ""
+  #
+  # A list of glob patterns to be used in identifying which resource cleanup providers
+  # to load as part of the custom resource cleanup monitor.
+  #
+  # Supported glob patterns include the following special characters:
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern 'dev.galasa*' will match any monitor that includes 'dev.galasa' as its prefix,
+  # so a class like 'dev.galasa.core.CoreResourceMonitorClass' will be matched.
+  #
+  # A pattern like '*MyResourceMonitorClass' will match any monitor that ends with 'MyResourceMonitorClass',
+  # such as 'my.company.monitors.MyResourceMonitorClass'.
+  includes: []
+  #
+  # A list of glob patterns to be used in identifying which resource cleanup providers
+  # should not be loaded as part of the custom resource cleanup monitor.
+  #
+  # Supported glob patterns include the following special characters:
+  # '*' (wildcard) Matches zero or more characters
+  # '?' matches exactly one character
+  #
+  # For example, the pattern '*' will match any monitor, so a class like 'dev.galasa.core.CoreResourceMonitorClass'
+  # will be matched.
+  #
+  # A pattern like '*MyResourceMonitorClass' will match any monitor that ends with 'MyResourceMonitorClass',
+  # such as 'my.company.monitors.MyResourceMonitorClass'.
+  excludes: []
+
+# The etcd pod houses the configuration property store, credentials store and the dynamic storage service.
+etcd:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "400m"
+      memory: "1000Mi"
+    limits:
+      cpu: "600m"
+      memory: "1500Mi"
+
+# The webui pod houses the web user interface.
+webui:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "300Mi"
+    limits:
+      cpu: "800m"
+      memory: "400Mi"
+
+# The engine controller receives requests to start tests, and starts pods in which
+# the tests run.
+enginecontroller:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "300Mi"
+    limits:
+      cpu: "800m"
+      memory: "500Mi"
+
+# The resource monitor is a component which monitors for failed/dead tests
+# and cleans up resources as required.
+resourcemonitor:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "300Mi"
+    limits:
+      cpu: "800m"
+      memory: "500Mi"
+
+# The couchdb component stores run history and records, user records and other
+# persistent storage objects.
+couchdb:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "400m"
+      memory: "300Mi"
+    limits:
+      cpu: "600m"
+      memory: "500Mi"
+
+# The metrics component gathers metrics from other components in the system.
+metrics:
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "300Mi"
+    limits:
+      cpu: "800m"
+      memory: "500Mi"
+
+# Best practice is to set memory limits for each pod.
+# So we need to set 4 things:
+# - The amount of cpu and memory requested for the pod immediately
+# - The amount of CPU and memory that the pod can grow to use
+# - The value that the MAX_HEAP env var should be set to for the JVM when it starts inside the pod
+# These values are placed in the config map which is loaded into settings in the engine controller, which
+# uses them to launch pods.
+testPod:
+  memory:
+    # All values are integers, in units of 'Mi'
+    heap: 350
+    min: 400
+    max: 800
+  cpu:
+    # All values are integers, in units of 'm'
+    # A value of 0 indicates no CPU minimum should be set.
+    min: 600
+    # A value of 0 indicates no CPU maximum should be set.
+    max: 1000

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -296,6 +296,18 @@ cleanupMonitor:
   # should not be loaded as part of the custom resource cleanup monitor.
   #
   # Supported glob patterns include the following special characters:
+  #
+  # Best practice is to set memory limits for each pod.
+  # This section sets some limits which Dex should be happy working within.
+  # Omitting this resources: section will cause no memory or cpi limits to be set.
+  # This default is suitable for a lightly loaded Galasa service:
+  resources:
+    requests:
+      cpu: "600m"
+      memory: "300Mi"
+    limits:
+      cpu: "800m"
+      memory: "500Mi"
 #
 #
 # resourceMonitor represents the values used to configure the system resource cleanup 


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

# Why ?
See story https://github.com/galasa-dev/projectmanagement/issues/2164

Pods can now have memory limits set via the helm chart.
Set the memory limits for ecosystem1
