### PR TITLE
CronJob to run the CICSTS and basic z/OS IVTs on prod1

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/run-cicsts-and-base-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-cicsts-and-base-zos-tests.yaml
@@ -1,0 +1,141 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: run-cicsts-and-base-zos-tests
+  namespace: galasa-dev
+spec:
+  schedule: 0 6 * * * # Daily at 06:00
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          initContainers:
+          - name: permissions
+            command:
+            - chmod
+            - -R
+            - "777"
+            - /galasa
+            image: ghcr.io/galasa-dev/busybox:1.36.1
+            imagePullPolicy: IfNotPresent
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          - name: clean
+            command:
+            - rm
+            - -rf
+            - /galasa/*
+            image: ghcr.io/galasa-dev/galasactl-ibm-x86_64:main
+            imagePullPolicy: Always
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          - name: run-submit
+            command:
+            - galasactl
+            - runs
+            - submit
+            - --bootstrap
+            - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+            - --stream
+            - ivts
+            # Overrides the current CPS property which says to use SEM.
+            - --override
+            - cicsts.provision.type=dse
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cicsts.CICSTSManagerIVT
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cemt.CEMTManagerIVT
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceda.CedaManagerIVT
+            # Currently not set up - will add in when it is...
+            # - --class
+            # - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceci.CECIManagerIVT
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270.Zos3270IVT
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerIVT
+            - --class
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerTSOCommandIVT
+            - --throttle
+            - "10"
+            - --poll
+            - "10"
+            - --progress 
+            - "1"
+            - --log
+            - "-"
+            image: ghcr.io/galasa-dev/galasactl-ibm-x86_64:main
+            imagePullPolicy: IfNotPresent
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            env:
+            - name: GALASA_HOME
+              value: /galasa
+            - name: GALASA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: galasa-prod1-token
+                  key: token
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          containers:
+          - name: submit-report
+            command:
+            - galasabld
+            - slackpost
+            - tests
+            - --path
+            - /galasa/test.json
+            - --hook
+            args:
+            - $(HOOK)
+            env:
+            - name: HOOK
+              valueFrom:
+                secretKeyRef:
+                  key: webhook
+                  name: slack-webhook
+            image: ghcr.io/galasa-dev/galasabld-ibm:main
+            imagePullPolicy: Always
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}      
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - emptyDir: {}
+            name: static-files
+
+  suspend: false


### PR DESCRIPTION
## Why?

Part of story https://github.com/galasa-dev/projectmanagement/issues/2189

This sets up a CronJob to run the CICSTS and basic z/OS Manager IVTs directly on prod1, which can replace the current "inttests" mechanism of spinning up a "local Galasa ecosystem" on a Linux VM and running the IVT there.

The `--override` flag is passed in to the `galasactl runs submit` to override the CICS TS provision method: the prod1 CPS props configure CICS regions to be provisioned with SEM, but for this set of tests, we want it to use the DSE region supplied, which is already in the CPS props so no need to override it. We don't want to change the CPS property in prod1 yet as we still have some CICS inttests left to replace.

I have tested the CronJob by running it manually and all tests Pass.

