### PR TITLE
removing cpu limits for helm deploy of ecosystem1

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml
@@ -167,10 +167,8 @@ dex:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "500m"
       memory: "300Mi"
     limits:
-      cpu: "700m"
       memory: "500Mi"
 
 
@@ -201,10 +199,8 @@ apiServer:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "500Mi"
     limits:
-      cpu: "1000m"
       memory: "800Mi"
 
   #
@@ -303,10 +299,8 @@ cleanupMonitor:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "300Mi"
     limits:
-      cpu: "900m"
       memory: "500Mi"
 #
 #
@@ -350,10 +344,8 @@ resourceMonitor:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "300Mi"
     limits:
-      cpu: "900m"
       memory: "500Mi"
 
 # The etcd pod houses the configuration property store, credentials store and the dynamic storage service.
@@ -363,10 +355,8 @@ etcd:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "500m"
       memory: "1000Mi"
     limits:
-      cpu: "700m"
       memory: "1500Mi"
 
 # The webui pod houses the web user interface.
@@ -376,10 +366,8 @@ webui:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "300Mi"
     limits:
-      cpu: "900m"
       memory: "400Mi"
 
 # The engine controller receives requests to start tests, and starts pods in which
@@ -390,10 +378,8 @@ enginecontroller:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "300Mi"
     limits:
-      cpu: "900m"
       memory: "500Mi"
 
 # The resource monitor is a component which monitors for failed/dead tests
@@ -404,10 +390,8 @@ resourcemonitor:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "700m"
       memory: "300Mi"
     limits:
-      cpu: "900m"
       memory: "500Mi"
 
 # The couchdb component stores run history and records, user records and other
@@ -418,10 +402,8 @@ couchdb:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "500m"
       memory: "300Mi"
     limits:
-      cpu: "700m"
       memory: "500Mi"
 
 # The metrics component gathers metrics from other components in the system.
@@ -431,10 +413,8 @@ metrics:
   # This default is suitable for a lightly loaded Galasa service:
   resources:
     requests:
-      cpu: "600m"
       memory: "300Mi"
     limits:
-      cpu: "800m"
       memory: "500Mi"
 
 # Best practice is to set memory limits for each pod.
@@ -453,8 +433,8 @@ testPod:
   cpu:
     # All values are integers, in units of 'm'
     # A value of 0 indicates no CPU minimum should be set.
-    min: 700
+    min: 0
     # A value of 0 indicates no CPU maximum should be set.
-    max: 1100
+    max: 0
 
   


### PR DESCRIPTION
Signed-off-by: Mike Cobbett <77053+techcobweb@users.noreply.github.com>

Helm is timing out. We suspect because the cpu values are set too low so everything takes longer than 5 mins to start up.

Removed the CPU limits and requested values. Lets see if that helps.
