### PR TITLE
Iss2189 - CronJob to run RSE API and z/OS MF IVTs

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/run-rse-api-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-rse-api-zos-tests.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: run-cicsts-and-base-zos-tests
+  name: run-rse-api-zos-tests
   namespace: galasa-dev
 spec:
   schedule: 0 6 * * * # Daily at 06:00
@@ -58,24 +58,17 @@ spec:
             - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
             - --stream
             - ivts
-            # Overrides the current CPS property which says to use SEM.
+            # Tells the IVTs to use the RSE API implementation of the z/OS Manager.
             - --override
-            - cicsts.provision.type=dse
+            - zos.bundle.extra.batch.manager=dev.galasa.zosbatch.rseapi.manager
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cicsts.CICSTSManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerBatchIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cemt.CEMTManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceda.CedaManagerIVT
-            # Currently not set up - will add in when it is...
-            # - --class
-            # - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceci.CECIManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileDatasetIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270.Zos3270IVT
-            - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerIVT
-            - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerTSOCommandIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileVSAMIVT
             - --throttle
             - "10"
             - --poll

--- a/infrastructure/cicsk8s/galasa-dev/run-zos-mf-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-zos-mf-zos-tests.yaml
@@ -7,7 +7,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: run-cicsts-and-base-zos-tests
+  name: run-zos-mf-zos-tests
   namespace: galasa-dev
 spec:
   schedule: 0 6 * * * # Daily at 06:00
@@ -58,24 +58,17 @@ spec:
             - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
             - --stream
             - ivts
-            # Overrides the current CPS property which says to use SEM.
+            # Tells the IVTs to use the z/OS MF implementation of the z/OS Manager.
             - --override
-            - cicsts.provision.type=dse
+            - zos.bundle.extra.batch.manager=dev.galasa.zosbatch.zosmf.manager
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cicsts.CICSTSManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerBatchIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.cemt.CEMTManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceda.CedaManagerIVT
-            # Currently not set up - will add in when it is...
-            # - --class
-            # - dev.galasa.zos.ivts/dev.galasa.zos.ivts.ceci.CECIManagerIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileDatasetIVT
             - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos3270.Zos3270IVT
-            - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerIVT
-            - --class
-            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerTSOCommandIVT
+            - dev.galasa.zos.ivts/dev.galasa.zos.ivts.zos.ZosManagerFileVSAMIVT
             - --throttle
             - "10"
             - --poll


### PR DESCRIPTION
## Why?

Part of story https://github.com/galasa-dev/projectmanagement/issues/2189

This sets up a CronJob to run the z/OS File, File Dataset, VSAM and Batch Manager IVTs against the RSE API and z/OS MF Managers directly on prod1 - this can replace the current "inttests" mechanism of spinning up a "local Galasa ecosystem" on a Linux VM and running the IVT there.

The --override flag is passed in to the galasactl runs submit to override the zos.bundle.extra.batch.manager - when specifying the RSE API Manager here the tests will run using RSE's implementation of Batch, and when specifying z/OS MF Manager it will use the z/OS MF implementation.