### PR TITLE
Tell galasabld what test suite we are reporting on

### DIFF
--- a/.github/workflows/non-zos-regression-test.yaml
+++ b/.github/workflows/non-zos-regression-test.yaml
@@ -83,4 +83,6 @@ jobs:
           ghcr.io/${{ env.NAMESPACE }}/galasabld-ibm:main \
           slackpost tests \
           --path /galasa/test.json \
+          --name "Core tests - ecosystem1" \
+          --desc "Core, HTTP, Artifact etc" \
           --hook ${{ env.SLACK_WEBHOOK }}

--- a/infrastructure/cicsk8s/galasa-dev/regression-test.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/regression-test.yaml
@@ -166,6 +166,10 @@ spec:
             - tests
             - --path
             - /galasa/test.json
+            - --name
+            - "inttests - prod1"
+            - --desc
+            - "Remaining inttests to be replaced"
             - --hook
             args:
             - $(HOOK)

--- a/infrastructure/cicsk8s/galasa-dev/run-cicsts-and-base-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-cicsts-and-base-zos-tests.yaml
@@ -113,6 +113,10 @@ spec:
             - tests
             - --path
             - /galasa/test.json
+            - --name
+            - "CICS and basic z/OS - prod1"
+            - --desc
+            - "All CICS TS, 3270, z/OS Manager, TSO"
             - --hook
             args:
             - $(HOOK)

--- a/infrastructure/cicsk8s/galasa-dev/run-rse-api-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-rse-api-zos-tests.yaml
@@ -106,6 +106,10 @@ spec:
             - tests
             - --path
             - /galasa/test.json
+            - --name
+            - "RSE API - prod1"
+            - --desc
+            - "RSE API testing of z/OS Batch and File Managers"
             - --hook
             args:
             - $(HOOK)

--- a/infrastructure/cicsk8s/galasa-dev/run-zos-mf-zos-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-zos-mf-zos-tests.yaml
@@ -106,6 +106,10 @@ spec:
             - tests
             - --path
             - /galasa/test.json
+            - --name
+            - "z/OS MF - prod1"
+            - --desc
+            - "z/OS MF testing of z/OS Batch and File Managers"
             - --hook
             args:
             - $(HOOK)


### PR DESCRIPTION
## Why?

Give info to `galasabld slackpost tests` command to label the different test reports - Now we have a few different test suites all reporting into Slack, we should have more output from galasabld that helps distinguish them.