### PR TITLE
Iss2165 - Update release instructions

### DIFF
--- a/releasePipeline/52-deploy-cli-release.md
+++ b/releasePipeline/52-deploy-cli-release.md
@@ -1,7 +1,7 @@
 # Deploy the CLI to the repo release
 
 1. Download the binary images from the website <https://development.galasa.dev/release/binary/cli/>
-1. Create a new release at <https://github.com/galasa-dev/cli/releases/new>
+1. Create a new release at <https://github.com/galasa-dev/galasa/releases/new>
     - Upload the binaries to it.
     - Select the latest tag
     - Give it a title

--- a/releasePipeline/95-move-to-new-version.md
+++ b/releasePipeline/95-move-to-new-version.md
@@ -16,6 +16,8 @@ These are manual steps to bump the version of Galasa to the next version.
 
     e. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
+    f. When the Isolated Main build is triggered following the CLI module build, cancel it on the GitHub UI [here](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) with the "Cancel Workflow" button, as you are going to rebuild it in a next step anyway.
+
     **Note:** Once the Galasa mono repo's build finishes, this will trigger the `recycle-prod1` Tekton pipeline, which will then trigger the `run-tests` Tekton pipeline. The `run-tests` will fail as the CPS properties have not yet been upgraded to the new development version (unless you have already done it with galasactl) - this is okay.
 
 3. Upgrade [Helm](https://github.com/galasa-dev/helm)
@@ -48,17 +50,7 @@ These are manual steps to bump the version of Galasa to the next version.
     
     b. Push the changes to your branch, open a PR, then merge in the PR, and wait for the Main build to pass and finish.
 
-8. Upgrade [CLI](https://github.com/galasa-dev/cli)
-
-    a. Invoke the `set-version --version {new version}` script.
-
-    b. Make sure it builds with `build-locally.sh`. This will also uplift the version in the generated docs files.
-
-    c. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
-
-    d. When the Isolated Main build is triggered, cancel it on the GitHub UI [here](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) with the "Cancel Workflow" button, as you are going to rebuild it in the next step anyway.
-
-9. Upgrade [Isolated](https://github.com/galasa-dev/isolated)
+8. Upgrade [Isolated](https://github.com/galasa-dev/isolated)
 
     a. Invoke the `set-version --version {new version}` script.
 

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -39,10 +39,8 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
     - Branch: `pre-release`
     - Enable Jacoco code coverage: `false`
     - Artifacts should be signed: `true`
-8. The build of the CLI repository and Isolated repository will be triggered automatically as part of the build chain, so monitor those builds and make sure they finish successfully. 
-    - The [CLI Main build workflow](https://github.com/galasa-dev/cli/actions/workflows/build.yml) should run with the `prerelease` ref
-    - This will trigger the Tekton pipeline `test-cli-ecosystem-commands` so go to the Tekton dashboard
-    - That will then trigger the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
+8. The build of the Isolated repository will be triggered automatically as part of the build chain, so monitor this build and make sure it finishes successfully. 
+    - Watch the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
 9. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `pre-release`
 10. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -39,10 +39,8 @@ For each of the Kubernetes Tekton command, you can follow with tkn -n galasa-bui
     - Branch: `release`
     - Enable Jacoco code coverage: `false`
     - Artifacts should be signed: `true`
-2. The build of the CLI repository and Isolated repository will be triggered automatically as part of the build chain, so monitor those builds and make sure they finish successfully. 
-    - The [CLI Main build workflow](https://github.com/galasa-dev/cli/actions/workflows/build.yml) should run with the `release` ref
-    - This will trigger the Tekton pipeline `test-cli-ecosystem-commands` so go to the Tekton dashboard
-    - That will then trigger the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `release` ref back in GitHub
+2. The build of the Isolated repository will be triggered automatically as part of the build chain, so monitor this build and make sure it finishes successfully. 
+    - Watch the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `release` ref back in GitHub
 3. Run the Web UI Main build. Select the "Run workflow" button on [this page](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) and select the following inputs:
    - Branch: `release`
 4. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`release`' option.

--- a/trigger-pipeline.sh
+++ b/trigger-pipeline.sh
@@ -90,10 +90,6 @@ while [ "$1" != "" ]; do
                                     ;;
         --recycle-prod1 )           pipeline="recycle-prod1"
                                     ;;
-        --run-tests )                pipeline="run-tests"
-                                    ;;
-        --test-cli )                pipeline="test-cli-ecosystem-commands"
-                                    ;;
         -p | --pipeline )           shift
                                     pipeline=$1
                                     ;;


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2165

Update references to the old CLI repo to the mono repo now it lives in there.