### PR TITLE
Bump CPS properties to 0.42.0, minor fixes to release scripts

### DIFF
--- a/.github/workflows/create-galasa-branch.yaml
+++ b/.github/workflows/create-galasa-branch.yaml
@@ -22,7 +22,7 @@ jobs:
     branch-create-galasa:
       strategy:
         matrix:
-          repo: ['automation', 'galasa', 'cli', 'isolated', 'helm', 'webui', 'simplatform']
+          repo: ['automation', 'galasa', 'isolated', 'helm', 'webui', 'simplatform']
       runs-on: ubuntu-latest
       steps:
         - name: Clone branch ${{ matrix.repo }}

--- a/.github/workflows/delete-branch-all.yaml
+++ b/.github/workflows/delete-branch-all.yaml
@@ -11,7 +11,7 @@ jobs:
     branch-delete-all:
       strategy:
         matrix:
-          repo: ['automation', 'galasa', 'cli', 'isolated', 'helm', 'webui', 'simplatform']
+          repo: ['automation', 'galasa', 'isolated', 'helm', 'webui', 'simplatform']
       runs-on: ubuntu-latest
       steps:
         - name: Delete branch ${{ matrix.repo }}

--- a/.github/workflows/tag-branch-galasa.yaml
+++ b/.github/workflows/tag-branch-galasa.yaml
@@ -14,7 +14,7 @@ jobs:
     branch-tag-galasa:
       strategy:
         matrix:
-          repo: ['automation', 'galasa', 'cli', 'isolated', 'helm', 'webui', 'simplatform']
+          repo: ['automation', 'galasa', 'isolated', 'helm', 'webui', 'simplatform']
       runs-on: ubuntu-latest
       steps:
         - name: Tag branch ${{ matrix.repo }}

--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -21,7 +21,7 @@ metadata:
     namespace: framework
     name: test.stream.ivts.location
 data:
-    value: https://development.galasa.dev/main/maven-repo/ivts/dev/galasa/dev.galasa.ivts.obr/0.41.0/dev.galasa.ivts.obr-0.41.0-testcatalog.json
+    value: https://development.galasa.dev/main/maven-repo/ivts/dev/galasa/dev.galasa.ivts.obr/0.42.0/dev.galasa.ivts.obr-0.42.0-testcatalog.json
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -29,7 +29,7 @@ metadata:
     namespace: framework
     name: test.stream.ivts.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.ivts.obr/0.41.0/obr
+    value: mvn:dev.galasa/dev.galasa.ivts.obr/0.42.0/obr
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -45,7 +45,7 @@ metadata:
     namespace: framework
     name: test.stream.inttests.location
 data:
-    value: https://development.galasa.dev/main/maven-repo/inttests/dev/galasa/dev.galasa.inttests.obr/0.41.0/dev.galasa.inttests.obr-0.41.0-testcatalog.json
+    value: https://development.galasa.dev/main/maven-repo/inttests/dev/galasa/dev.galasa.inttests.obr/0.42.0/dev.galasa.inttests.obr-0.42.0-testcatalog.json
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -53,7 +53,7 @@ metadata:
     namespace: framework
     name: test.stream.inttests.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.inttests.obr/0.41.0/obr 
+    value: mvn:dev.galasa/dev.galasa.inttests.obr/0.42.0/obr 
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -190,7 +190,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.full.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.41.0/galasa-isolated-0.41.0.zip
+    value: https://development.galasa.dev/main/maven-repo/isolated/dev/galasa/galasa-isolated/0.42.0/galasa-isolated-0.42.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -198,7 +198,7 @@ metadata:
     namespace: galasaecosystem
     name: isolated.mvp.zip
 data:
-    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.41.0/galasa-isolated-mvp-0.41.0.zip
+    value: https://development.galasa.dev/main/maven-repo/mvp/dev/galasa/galasa-isolated-mvp/0.42.0/galasa-isolated-mvp-0.42.0.zip
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -230,7 +230,7 @@ metadata:
     namespace: galasaecosystem
     name: galasaboot.version
 data:
-    value: 0.41.0
+    value: 0.42.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -254,7 +254,7 @@ metadata:
     namespace: galasaecosystem
     name: runtime.version
 data:
-    value: 0.41.0
+    value: 0.42.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -262,7 +262,7 @@ metadata:
     namespace: galasaecosystem
     name: simbanktests.version
 data:
-    value: 0.41.0
+    value: 0.42.0
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -278,4 +278,4 @@ metadata:
     namespace: galasaecosystem
     name: simplatform.version
 data:
-    value: 0.41.0
+    value: 0.42.0

--- a/releasePipeline/03-repo-branches-delete.sh
+++ b/releasePipeline/03-repo-branches-delete.sh
@@ -115,7 +115,7 @@ function delete_branches {
 
     echo "Workflow started with Run ID: ${run_id}"
     
-    echo -e "\e]8;;https://github.com/${github_username}/automation/actions/runs/${run_id}\e\\Open Workflow Log\e]8;;\e\\ for more info."
+    echo "Open Workflow Log at https://github.com/${github_username}/automation/actions/runs/${run_id} for more info."
 
 
     MAX_WAIT_ITERATIONS=30

--- a/releasePipeline/04-repo-branches-create.sh
+++ b/releasePipeline/04-repo-branches-create.sh
@@ -120,7 +120,7 @@ function create_branches {
 
     echo "Workflow started with Run ID: ${run_id}"
 
-    echo -e "\e]8;;https://github.com/${github_username}/automation/actions/runs/${run_id}\e\\Open Workflow Log\e]8;;\e\\ for more info."
+    echo "Open Workflow Log at https://github.com/${github_username}/automation/actions/runs/${run_id} for more info."
 
 
     MAX_WAIT_ITERATIONS=30

--- a/releasePipeline/05-helm-charts.sh
+++ b/releasePipeline/05-helm-charts.sh
@@ -230,7 +230,7 @@ function delete_pre_release_helm_charts {
         release_url=$(grep -Ei ' *"url" *: *"(https:\/\/api\.github\.com\/repos\/galasa-dev\/helm\/releases\/[0-9]*)"' $release_json_details | cut -d \" -f 4)
 
         # Delete pre-release github release
-        response_code= $(curl -X DELETE $release_url -w "${response_code}")
+        response_code=$(curl -X DELETE $release_url -w "${response_code}")
         if [[ "${response_code}" != "204" ]]; then 
             error "Unable to delete release for $release_tag using the api url '$release_url'. Expected status code '204' and got '$response_code'."
             exit 1

--- a/releasePipeline/30-deploy-maven-galasa.sh
+++ b/releasePipeline/30-deploy-maven-galasa.sh
@@ -121,7 +121,7 @@ function deploy_maven_artifacts {
 
     echo "Workflow started with Run ID: ${run_id}"
 
-    echo -e "\e]8;;https://github.com/${github_username}/automation/actions/runs/${run_id}\e\\Open Workflow Log\e]8;;\e\\ for more info."
+    echo "Open Workflow Log at https://github.com/${github_username}/automation/actions/runs/${run_id} for more info."
 
 
     MAX_WAIT_ITERATIONS=30

--- a/releasePipeline/33-build-resources-image.sh
+++ b/releasePipeline/33-build-resources-image.sh
@@ -94,12 +94,12 @@ function create_resources_image {
 
     h1 "Creating the resources image..."
 
-    dist_branch="release"
+    branch="release"
     version="${galasa_version}"
 
     github_username="galasa-dev"
 
-    workflow_dispatch=$( gh workflow run "build resources" --repo ${github_username}/automation --ref main --field distBranch=${dist_branch} --field version=${version})
+    workflow_dispatch=$( gh workflow run "build resources" --repo ${github_username}/automation --ref ${branch} --field version=${version})
     if [[ $? != 0 ]]; then
         error "Failed to call the workflow. $?"
         exit 1
@@ -115,7 +115,7 @@ function create_resources_image {
     fi
 
     echo "Workflow started with Run ID: ${run_id}"
-    echo -e "\e]8;;https://github.com/${github_username}/automation/actions/runs/${run_id}\e\\Open Workflow Log\e]8;;\e\\ for more info."
+    echo "Open Workflow Log at https://github.com/${github_username}/automation/actions/runs/${run_id} for more info."
 
     success "Resources image build pipeline kicked off OK."
 }

--- a/releasePipeline/50-tag-github-repositories.sh
+++ b/releasePipeline/50-tag-github-repositories.sh
@@ -117,7 +117,7 @@ function tag_galasa_github_repositories {
 
     echo "Workflow started with Run ID: ${run_id}"
 
-    echo -e "\e]8;;https://github.com/${github_username}/automation/actions/runs/${run_id}\e\\Open Workflow Log\e]8;;\e\\ for more info."
+    echo "Open Workflow Log at https://github.com/${github_username}/automation/actions/runs/${run_id} for more info."
 
 
     MAX_WAIT_ITERATIONS=30

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -21,7 +21,7 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 3. Run [25-check-artifacts-signed.sh](./25-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - Each maven artifact should contain a file called com.auth0.jwt-<*VERSION*>.jar.asc. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
-4. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino or Will Yates to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+4. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
 
 ## Pre-release steps - Manual
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2171

## Changes
- Bumped version-related CPS properties from 0.41.0 to 0.42.0
- Removed CLI repo from workflows for creating release branches, deleting release branches, and creating release tags
- Replaced ANSI formatting in release scripts with plain URLs to avoid control characters from appearing in different shells