### PR TITLE
Iss2190 - Set up new Simbank tests to replace inttests

### DIFF
--- a/.github/workflows/regression-tests-core-non-zos.yaml
+++ b/.github/workflows/regression-tests-core-non-zos.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-name: Run Galasa regression tests (non z/OS)
+name: Galasa Core Regression Tests (non z/OS)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/regression-tests-simbank.yaml
+++ b/.github/workflows/regression-tests-simbank.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Galasa Simbank Regression Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *" # Daily at 06:00
+
+jobs:
+  trigger-workflow:
+    name: Trigger 'Test SimBank' Workflow
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger 'Test SimBank' Workflow in the Simbank Repository
+      env:
+        GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      run: |
+        gh workflow run test.yaml --repo https://github.com/galasa-dev/simplatform


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2190

Part of the efforts to replace all the old inttests that rely on the Linux VMs with new tests.

- This PR adds a new GH workflow that runs on a daily schedule at 6am as part of the regression suite, that calls a workflow in the Simbank repository that runs the `SimBankIVT`, `BasicAccountCreditTest` and `ProvisionedAccountCreditTests`. This is the equivalent of what the inttest `SimbankLocalJava11Ubuntu` does so that test can be removed once this is merged.
- This PR also renames the other GH workflow that runs the core tests so the file names and workflow names have consistency.