### PR TITLE
Check back in ExternalSecret argocd-token

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/secret-argocd.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/secret-argocd.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: argocd-token
+  namespace: galasa-development
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: ibmcloud-secrets-manager
+    kind: SecretStore
+  target:
+    name: argocd-token
+    template:
+      type: Opaque
+
+  data:
+  - secretKey: argocd-token
+    # Corresponds to the secret: 'planb-argocd-cli-token' #pragma: allowlist secret 
+    remoteRef:
+      key: arbitrary/afab7757-3485-7755-b1b1-9190d65b5097


### PR DESCRIPTION
## Why?

Check back in ExternalSecret argocd-token for the external cluster as it was accidentally deleted in PR #706 

