### PR TITLE
Add compilation tests CronJob

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/run-compilation-tests.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/run-compilation-tests.yaml
@@ -1,0 +1,127 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: run-compilation-tests
+  namespace: galasa-dev
+spec:
+  schedule: 0 6 * * * # Daily at 06:00
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          initContainers:
+          - name: permissions
+            command:
+            - chmod
+            - -R
+            - "777"
+            - /galasa
+            image: ghcr.io/galasa-dev/busybox:1.36.1
+            imagePullPolicy: IfNotPresent
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          - name: clean
+            command:
+            - rm
+            - -rf
+            - /galasa/*
+            image: ghcr.io/galasa-dev/galasactl-ibm-x86_64:main
+            imagePullPolicy: Always
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          - name: run-submit
+            command:
+            - galasactl
+            - runs
+            - submit
+            - --bootstrap
+            - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+            - --stream
+            - ivts
+            - --class
+            - dev.galasa.ivts/dev.galasa.ivts.compilation.TestCompilationIsolated
+            - --class
+            - dev.galasa.ivts/dev.galasa.ivts.compilation.TestCompilationMVP
+            - --throttle
+            - "10"
+            - --poll
+            - "10"
+            - --progress 
+            - "1"
+            - --trace
+            - --reportjson
+            - /galasa/test.json
+            - --noexitcodeontestfailures
+            - --log
+            - "-"
+            image: ghcr.io/galasa-dev/galasactl-ibm-x86_64:main
+            imagePullPolicy: IfNotPresent
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            env:
+            - name: GALASA_HOME
+              value: /galasa
+            - name: GALASA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: galasa-prod1-token
+                  key: token
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          containers:
+          - name: submit-report
+            command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              galasabld slackpost tests --path /galasa/test.json --name="Compilation - prod1" --desc="Tests that build a Gradle-based Galasa project using dependencies from Isolated and MVP packaging" --hook $(HOOK)
+            env:
+            - name: HOOK
+              valueFrom:
+                secretKeyRef:
+                  key: webhook
+                  name: slack-webhook
+            image: ghcr.io/galasa-dev/galasabld-ibm:main
+            imagePullPolicy: Always
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /galasa
+              name: static-files
+
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}      
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - emptyDir: {}
+            name: static-files
+
+  suspend: false


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2190
Related to changes in https://github.com/galasa-dev/galasa/pull/330

## Changes
- Added a CronJob that runs the new Docker-based compilation tests on the prod1 service