### PR TITLE
Add workflow to apply Galasa resources to ecosystem1

### DIFF
--- a/.github/workflows/apply-galasa-resources.yaml
+++ b/.github/workflows/apply-galasa-resources.yaml
@@ -20,6 +20,9 @@ jobs:
     name: Apply Galasa resources YAML file
     runs-on: ubuntu-latest
 
+    # Don't run this job for forks.
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+
     steps:
       - name: Checkout Galasa resources file
         uses: actions/checkout@v4

--- a/.github/workflows/apply-galasa-resources.yaml
+++ b/.github/workflows/apply-galasa-resources.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Apply Galasa Resources for 'ecosystem1'
+
+on:
+  push:
+    branches: 
+      - 'main'
+
+env:
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+  # This workflow applies the Galasa resources YAML file used by the 'ecosystem1' Galasa service.
+  apply-galasa-resources:
+    name: Apply Galasa resources YAML file
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Galasa resources file
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
+          sparse-checkout-cone-mode: false
+
+      - name: Ensure permissions for mounted /galasa directory
+        run: |
+          sudo mkdir -p ${{ github.workspace }}/galasa
+          sudo chown -R 999:999 ${{ github.workspace }}/galasa
+
+      - name: Clean /galasa workspace in CLI image
+        run: |
+          docker run --rm \
+          --user galasa:galasa \
+          -v ${{ github.workspace }}/galasa:/galasa \
+          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          rm -rf /galasa/*
+
+      - name: Run the 'galasactl resources apply' command
+        env:
+          GALASA_HOME: /galasa
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_ECOSYSTEM1 }}
+        run: |
+          docker run --rm \
+          --env GALASA_HOME=${{ env.GALASA_HOME }} \
+          --env GALASA_TOKEN=${{ env.GALASA_TOKEN }} \
+          --user galasa:galasa \
+          -v ${{ github.workspace }}/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml:/var/workspace/galasa-ecosystem1-resources.yaml \
+          -v ${{ github.workspace }}/galasa:/galasa:rw \
+          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          galasactl resources apply \
+          --bootstrap https://galasa-ecosystem1.galasa.dev/api/bootstrap \
+          --file /var/workspace/galasa-ecosystem1-resources.yaml \
+          --log -

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
@@ -35,3 +35,14 @@ metadata:
     name: test.stream.ivts.repo
 data:
     value: https://development.galasa.dev/main/maven-repo/ivts/
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: service
+    name: welcome.markdown
+data:
+    value: |-
+        # Welcome to your Galasa service
+        To Make the most of your Galasa experience, please refer to the [Galasa documentation](https://galasa.dev/)
+        ![image](https://raw.githubusercontent.com/galasa-dev/webui/ee5cf521ebb392079b3d672c78ad2da128d8fef9/galasa-ui/public/static/homeGraphic.svg)

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# The Galasa resources defined in this file are applied to the 'ecosystem1' service.
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: framework
+    name: test.stream.ivts.description
+data:
+    value: Galasa IVTs
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: framework
+    name: test.stream.ivts.location
+data:
+    value: https://development.galasa.dev/main/maven-repo/ivts/dev/galasa/dev.galasa.ivts.obr/0.43.0/dev.galasa.ivts.obr-0.43.0-testcatalog.json
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: framework
+    name: test.stream.ivts.obr
+data:
+    value: mvn:dev.galasa/dev.galasa.ivts.obr/0.43.0/obr
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaProperty
+metadata:
+    namespace: framework
+    name: test.stream.ivts.repo
+data:
+    value: https://development.galasa.dev/main/maven-repo/ivts/


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2290

## Changes
- Added a YAML file containing GalasaProperty resources for the `ivts` test stream and the web UI service welcome markdown
- Added a workflow that runs `galasactl resources apply` on ecosystem1 to apply the YAML file mentioned above