### PR TITLE
Reinstate the test ecosystem1 step in the Helm workflow now that the ValidateEcosystem job has been fixed

### DIFF
--- a/.github/workflows/build-helm.yaml
+++ b/.github/workflows/build-helm.yaml
@@ -52,10 +52,9 @@ jobs:
         run: |
           helm install main-ecosystem ${{ github.workspace }}/helm/charts/ecosystem --namespace=galasa-ecosystem1 --values ${{ github.workspace }}/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/helm-values.yaml --kubeconfig $HOME/.kube/config --timeout 10m0s --wait
 
-      # Commenting out for now as the validate-ecosystem Job will fail due to recent changes.
-      # - name: Test ecosystem1
-      #   run: |
-      #     helm test main-ecosystem --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
+      - name: Test ecosystem1
+        run: |
+          helm test main-ecosystem --namespace=galasa-ecosystem1 --kubeconfig $HOME/.kube/config
 
   trigger-next-workflow:
     # Skip this job for forks


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/projectmanagement/issues/2344