### PR TITLE
Add cert-manager docs and galasa2.galasa.dev entry to DNS table in readme, add YAML files for cert-manager resources

### DIFF
--- a/infrastructure/dns/readme.md
+++ b/infrastructure/dns/readme.md
@@ -19,6 +19,7 @@ These are the settings currently held in the DNS table currently.
 | A | copyright.galasa.dev | 169.50.192.70 ||
 | A | development.galasa.dev | 169.50.192.70 ||
 | A | dex.galasa.dev | 169.50.192.70 | What is this one ? |
+| A | galasa2.galasa.dev | 169.50.192.66 | Created to try out cert-manager for a Galasa service. Maps to the IP of the ingress-nginx-controller LoadBalancer in the ingress-nginx namespace |
 | A | galasa-ecosystem1.galasa.dev | 169.50.192.70 ||
 | A | hobbit.galasa.dev | 169.50.192.70 | old. Can be deleted. |
 | A | javadoc.galasa.dev | URL redirect to https://galasa.dev/docs/reference/javadoc/ | |

--- a/infrastructure/galasa-plan-b-lon02/galasa2/certificate.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa2/certificate.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: galasa2-cert
+spec:
+  secretName: galasa2-cert-secret
+  dnsNames:
+  - galasa2.galasa.dev
+  issuerRef:
+    name: letsencrypt-prod
+    kind: Issuer

--- a/infrastructure/galasa-plan-b-lon02/galasa2/namespace.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa2/namespace.yaml
@@ -1,0 +1,9 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: galasa2

--- a/infrastructure/galasa-plan-b-lon02/galasa2/prod-issuer.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa2/prod-issuer.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This is a namespaced Issuer resource that requests certificates to be issued from the Let's Encrypt
+# production issuer. The production issuer has very strict rate limits, so to avoid hitting
+# them when experimenting with changes, use the letsencrypt-staging issuer instead.
+# 
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # The ACME certificate profile
+    profile: tlsserver
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/infrastructure/galasa-plan-b-lon02/galasa2/staging-issuer.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa2/staging-issuer.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This is a namespaced Issuer resource that requests certificates to be issued from the Let's Encrypt
+# staging issuer. The staging issuer should be used for development and testing purposes only.
+# Use the letsencrypt-prod issuer for production use.
+# 
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # The ACME certificate profile
+    profile: tlsserver
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx

--- a/infrastructure/galasa-plan-b-lon02/readme.md
+++ b/infrastructure/galasa-plan-b-lon02/readme.md
@@ -5,8 +5,8 @@
 This cluster has the following applications set up:
 
 - [argocd](https://argocd.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud)
-
-
+- [cert-manager](https://cert-manager.io)
+- [ingress-nginx](https://kubernetes.github.io/ingress-nginx)
 
 ## Notes about this cluster
 
@@ -17,3 +17,68 @@ This cluster has the following applications set up:
 Create applications in argocd using the `argo-app-create.sh` script.
 
 > Read + Change it before you run it.
+
+# cert-manager
+cert-manager has been installed into the cluster using Helm, and it lives in the `cert-manager` namespace.
+
+To install cert-manager (version v1.18.2 at the time of writing), run:
+
+```
+helm install \
+  cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version v1.18.2 \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+```
+
+To issue a certificate:
+
+1. Create an `Issuer` resource (or a `ClusterIssuer` for cluster-wide certificate issuing), for example:
+
+```yaml
+# This is a namespaced Issuer resource that requests certificates to be issued from the Let's Encrypt
+# staging issuer. The staging issuer should be used for development and testing purposes only.
+# 
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: user@example.com
+    # The ACME certificate profile
+    profile: tlsserver
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: nginx
+```
+
+2. Create a `Certificate` resource:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-certificate
+spec:
+  # The name of the TLS secret to be created
+  # for use in Ingress TLS definitions
+  secretName: my-cert-secret
+  dnsNames:
+  - example.com
+  issuerRef:
+    # The Issuer that you would like to use to issue
+    # this certificate
+    name: letsencrypt-staging
+    kind: Issuer
+
+```


### PR DESCRIPTION
## Why?
Relates to https://github.com/galasa-dev/projectmanagement/issues/2327

## Changes
- Added galasa2.galasa.dev A record to the table in the DNS README
- Updated external cluster README to include docs on cert-manager
- Added YAML files for the resources that can be used to issue a certificate for galasa2.galasa.dev