### PR TITLE
Update release docs based on steps taken during 0.43.0 release + minor script improvements

### DIFF
--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -17,8 +17,6 @@
 RELEASE_BASEDIR=$(dirname "$0");pushd $RELEASE_BASEDIR 2>&1 >> /dev/null ;RELEASE_BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 export ORIGINAL_DIR=$(pwd)
 cd "${RELEASE_BASEDIR}"
-CALLED_BY_PRERELEASE="true"
-export release_type="prerelease" 
 
 #--------------------------------------------------------------------------
 #
@@ -54,48 +52,27 @@ note()      { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset
 #-----------------------------------------------------------------------------------------                   
 # Main Program
 #-----------------------------------------------------------------------------------------   
-function load_script {
-    cd ${RELEASE_BASEDIR}
-    script_path="$1"
-
-    source "${script_path}"
-}
-
 set -e
 
-load_script $RELEASE_BASEDIR/02-create-argocd-apps.sh
 h1 "run 02-create-argocd-apps.sh"
-create_maven_repos
-create_cli
+$RELEASE_BASEDIR/02-create-argocd-apps.sh --prerelease
 
-load_script $RELEASE_BASEDIR/03-repo-branches-delete.sh
 h1 "run 03-repo-branches-delete.sh"
-set_kubernetes_context
-delete_branches
+$RELEASE_BASEDIR/03-repo-branches-delete.sh --prerelease
 
-load_script $RELEASE_BASEDIR/04-repo-branches-create.sh
 h1 "run 04-repo-branches-create.sh"
-set_kubernetes_context
-create_branches
+$RELEASE_BASEDIR/04-repo-branches-create.sh --prerelease
 
-load_script $RELEASE_BASEDIR/05-helm-charts.sh
 h1 "run 05-helm-charts.sh"
-get_galasa_version_to_be_released
-clone_helm_repository
-get_helm_charts
-check_helm_charts_released
-delete_pre_release_helm_charts
+$RELEASE_BASEDIR/05-helm-charts.sh --prerelease
 
-load_script $RELEASE_BASEDIR/20-build-all-code.sh
-h1 "run 20-build-all-code.sh"
-ask_user_for_release_type
-set_kubernetes_context
-build_all_code
+h1 "run 10-build-galasa-mono-repo.sh"
+$RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --prerelease --wait
 
 # This will need to be removed once the webui is built as part of the main build chain
 # (see https://github.com/galasa-dev/projectmanagement/issues/1960)
-load_script $RELEASE_BASEDIR/21-build-webui.sh
-h1 "run 21-build-webui.sh"
-ask_user_for_release_type
-set_kubernetes_context
-build_webui
+h1 "run 11-build-webui.sh"
+$RELEASE_BASEDIR/11-build-webui.sh --prerelease
+
+h1 "run 20-check-artifacts-signed.sh"
+$RELEASE_BASEDIR/20-check-artifacts-signed.sh

--- a/releasePipeline/02-create-argocd-apps.sh
+++ b/releasePipeline/02-create-argocd-apps.sh
@@ -12,7 +12,14 @@
 # Environment variable over-rides:
 # 
 #-----------------------------------------------------------------------------------------                   
-
+function usage {
+    info "Syntax: 02-create-argocd-apps.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--prerelease : Creates the ArgoCD apps for a Galasa pre-release.
+--release : Creates the ArgoCD apps for a Galasa release.
+EOF
+}
 
 function ask_user_for_release_type {
     PS3="Select the type of release process please: "
@@ -113,12 +120,34 @@ function create_simplatform {
                     --grpc-web
 }
 
-# checks if it's been called by 01-run-pre-release.sh, if it isn't run all functions
-if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+release_type=""
+while [ "$1" != "" ]; do
+    case $1 in
+        --prerelease )          release_type="prerelease"
+                                ;;
+        --release )             release_type="release"
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+# ------------------------------------------------------------------------
+# Main logic
+# ------------------------------------------------------------------------
+if [[ -z "${release_type}" ]]; then
     ask_user_for_release_type
-    set -e
-    create_maven_repos
-    create_bld
-    create_cli
-    create_simplatform
 fi
+
+create_maven_repos
+create_bld
+create_cli
+create_simplatform

--- a/releasePipeline/03-repo-branches-delete.sh
+++ b/releasePipeline/03-repo-branches-delete.sh
@@ -54,8 +54,17 @@ bold() { printf "${bold}%s${reset}\n" "$@" ;}
 note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
 #-----------------------------------------------------------------------------------------                   
-# Main logic.
+# Functions
 #-----------------------------------------------------------------------------------------                   
+
+function usage {
+    info "Syntax: 03-repo-branches-delete.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--prerelease : Deletes any pre-release branches in the galasa-dev repositories.
+--release : Deletes any release branches in the galasa-dev repositories.
+EOF
+}
 
 function ask_user_for_release_type {
     PS3="Select the type of release process please: "
@@ -134,8 +143,32 @@ function delete_branches {
 
     success "All branches called ${release_type} are now deleted. Yay!"
 }
-# checks if it's been called by 01-run-pre-release.sh, if it isn't run all functions
-if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
+
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+release_type=""
+while [ "$1" != "" ]; do
+    case $1 in
+        --prerelease )          release_type="prerelease"
+                                ;;
+        --release )             release_type="release"
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+# ------------------------------------------------------------------------
+# Main logic
+# ------------------------------------------------------------------------
+if [[ -z "${release_type}" ]]; then
     ask_user_for_release_type
-    delete_branches
 fi
+
+delete_branches

--- a/releasePipeline/04-repo-branches-create.sh
+++ b/releasePipeline/04-repo-branches-create.sh
@@ -54,9 +54,17 @@ bold() { printf "${bold}%s${reset}\n" "$@" ;}
 note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
 #-----------------------------------------------------------------------------------------                   
-# Main logic.
+# Functions
 #-----------------------------------------------------------------------------------------                   
 
+function usage {
+    info "Syntax: 04-repo-branches-create.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--prerelease : Creates pre-release branches in the galasa-dev repositories.
+--release : Creates release branches in the galasa-dev repositories.
+EOF
+}
 
 function ask_user_for_release_type {
     PS3="Select the type of release process please: "
@@ -142,7 +150,31 @@ function create_branches {
 
 }
 
-if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+release_type=""
+while [ "$1" != "" ]; do
+    case $1 in
+        --prerelease )          release_type="prerelease"
+                                ;;
+        --release )             release_type="release"
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+# ------------------------------------------------------------------------
+# Main logic
+# ------------------------------------------------------------------------
+if [[ -z "${release_type}" ]]; then
     ask_user_for_release_type
-    create_branches
 fi
+
+create_branches

--- a/releasePipeline/11-build-webui.sh
+++ b/releasePipeline/11-build-webui.sh
@@ -55,10 +55,16 @@ note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" 
 
 
 #-----------------------------------------------------------------------------------------                   
-# Main logic.
+# Functions
 #-----------------------------------------------------------------------------------------                   
-
-mkdir -p temp
+function usage {
+    info "Syntax: 11-build-webui.sh [OPTIONS]"
+    cat << EOF
+Options are:
+--prerelease : Builds the Galasa web UI for a pre-release.
+--release : Builds the Galasa web UI for a release.
+EOF
+}
 
 function ask_user_for_release_type {
     PS3="Select the type of release process please: "
@@ -107,7 +113,32 @@ function build_webui {
 
 }
 
-if [[ "$CALLED_BY_PRERELEASE" == "" ]]; then
-  ask_user_for_release_type
-  build_webui
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+release_type=""
+while [ "$1" != "" ]; do
+    case $1 in
+        --prerelease )          release_type="prerelease"
+                                ;;
+        --release )             release_type="release"
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+# ------------------------------------------------------------------------
+# Main program logic
+# ------------------------------------------------------------------------
+mkdir -p temp
+if [[ -z "${release_type}" ]]; then
+    ask_user_for_release_type
 fi
+
+build_webui

--- a/releasePipeline/95-move-to-new-version.md
+++ b/releasePipeline/95-move-to-new-version.md
@@ -10,8 +10,6 @@ These are manual steps to bump the version of Galasa to the next version.
 
     b. Run the `./tools/build-locally.sh`, which will invoke each individual module's `build-locally.sh` script, which will update the versions in the generated `release.yaml`s.
 
-    **You will have to manually update the 'docs' for now as there is no set-version.sh. Update all versions in the documentation content, apart from the file with the release notes for the released version.**
-
     c. Manually check that all dev.galasa bundles have been upgraded. Do a search for the current version in VSCode to check for any versions that did not get uplifted by the script, and replace with the new development version.
 
     d. Make sure the API Server starts locally.

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -21,7 +21,7 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 3. Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - Each maven artifact should contain a file called com.auth0.jwt-<*VERSION*>.jar.asc. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
-4. Send the [mvp image](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+4. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs](https://github.ibm.com/galasa/developer-docs/blob/322ea364dd63ad533427c984c6c7dd4c5f8c75cc/docs/300-process/dfg-build-process.md) to check for any vulnerabilities before moving onto the release process.
 
 ## Pre-release steps - Manual
 
@@ -41,7 +41,7 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
 9. Now run the Web UI Main build. Run [11-build-webui.sh](./11-build-webui.sh). When prompted, choose the '`pre-release`' option. This script uses the GitHub CLI to start the [Main build](https://github.com/galasa-dev/webui/actions/workflows/build.yaml). You will have to monitor the workflow run and ensure it finishes successfully.
 10. Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
-11. Send the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) to Jade Carino to perform the MEND scan to check for any vulnerabilities before moving onto the release process.
+11. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs](https://github.ibm.com/galasa/developer-docs/blob/322ea364dd63ad533427c984c6c7dd4c5f8c75cc/docs/300-process/dfg-build-process.md) to check for any vulnerabilities before moving onto the release process.
 12. **Note:** A [story](https://github.com/galasa-dev/projectmanagement/issues/2108) exists to automate this manual process for future releases. Test the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by working through the instructions on the Galasa website to do with using Galasa offline (although you will need to slightly adapt in some places as you are testing the MVP from the prerelease maven repo - these differences are documented below):
     - https://galasa.dev/docs/cli-command-reference/installing-offline
         - 1: The output of `docker load -i isolated.tar` should instead be `Loaded image: ghcr.io/galasa-dev/galasa-mvp:main`.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -147,7 +147,7 @@ Once an approver has approved, you can move on.
 ### Bump to new version for development
 
 1. [95-move-to-new-version.md](./95-move-to-new-version.md) - Follow the manual steps in this file to upgrade the development version of Galasa to the next one up.
-2. In the file `../infrastructure/cicsk8s/galasa-dev/cps-properties.yaml` update all CPS properties that contain the just released version to contain the new development version number. Deliver the changes to the automation repository and the CPS properties will be applied automatically.
+2. Run the [set-version.sh](./set-version.sh) script which updates all CPS properties in the [`../infrastructure/cicsk8s/galasa-dev/cps-properties.yaml`](../infrastructure/cicsk8s/galasa-dev/cps-properties.yaml) file that contain the version that was just released to the new development version. Deliver the changes to the automation repository and the CPS properties will be applied automatically.
 
 3. If the above fails and you need to update the CPS properties manually for some reason, run the [99-update-development-version.sh](./99-update-development-version.sh) script.
 
@@ -167,7 +167,7 @@ docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
 
 ### Clean up
 
-1. Run [03-repo-branches-delete.sh](./03-repo-branches-delete.sh) - Say you are doing a 'release' when it asks. That Deletes the 'release' branch in the GitHub repositories.
+1. Run [03-repo-branches-delete.sh](./03-repo-branches-delete.sh) - Say you are doing a 'release' when it asks. That deletes the 'release' branch in the GitHub repositories.
 2. (**Manual until we automate it with GitHub Actions**) Delete the images in GHCR tagged 'release':
    - obr-maven-artefacts
    - obr-generic


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2273

## Changes
Scripts:
- Updated the 01-run-pre-release.sh script to call other scripts using a `--prerelease` flag instead of sourcing the scripts
- Added `--prerelease` and `--release` flags for other scripts used in the release process to make it easier to call them from other locations

Docs:
- Removed mention of manually updating versions in the `docs` module since a set-version script does exist
- Replaced explicit mention of sending the MVP zip to Jade for MEND scanning with a link to the relevant instructions to do this yourself (Note: the link currently directs to the source markdown file in GitHub)
- Added doc on using the set-version.sh script in the automation repo to update the versions in the cps-properties.yaml file