### PR TITLE
Use the cert-installer chart to issue a certificate for argocd.galasa.dev

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/argocd/argocd-ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/argocd/argocd-ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - argocd.galasa.dev
-    secretName: argocd-server-tls
+    secretName: argocd-tls-secret
   rules:
   - host: argocd.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/argocd/cert-installer-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/argocd/cert-installer-values.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# A list of DNS names to issue a certificate for
+# For example, to issue a certificate for 'myservice.galasa.dev', the value would look like:
+#
+# dnsNames:
+#   - myservice.galasa.dev
+#
+dnsNames:
+  - argocd.galasa.dev
+
+# The name of the ingress class that you are using for your exposed Ingress resources.
+# Different cloud providers may offer their own ingress classes. For example, IBM Cloud
+# offers 'public-iks-k8s-nginx' and 'private-iks-k8s-nginx' classes.
+ingressClassName: public-iks-k8s-nginx
+
+# Determines whether the Issuer resource should use a production URL to issue certificates.
+# When `useIssuerProductionUrl` is false, the ACME staging URL will be used (https://acme-staging-v02.api.letsencrypt.org/directory).
+# When `useIssuerProductionUrl` is true, the ACME production URL will be used (https://acme-v02.api.letsencrypt.org/directory).
+# This value should only be set to true once you have made sure that certificates can be issued successfully using the staging URL.
+useIssuerProductionUrl: true
+
+# The email that should receive messages from Let's Encrypt about expiring certificates
+# and any issues associated with your account.
+#
+# Note: There is no mechanism to load an email from a secret, so one has been set on installation.
+# Run "kubectl describe issuer argocd-tls-letsencrypt-prod" to get the email that has been set.
+email: ""

--- a/infrastructure/galasa-plan-b-lon02/readme.md
+++ b/infrastructure/galasa-plan-b-lon02/readme.md
@@ -38,6 +38,7 @@ The [cert-installer](https://github.com/galasa-dev/helm/tree/main/charts/cert-in
 
 Namespaces in which cert-installer has been installed in:
 
+- argocd
 - galasa-ecosystem1
 - galasa2
 

--- a/infrastructure/galasa-plan-b-lon02/readme.md
+++ b/infrastructure/galasa-plan-b-lon02/readme.md
@@ -36,11 +36,23 @@ helm install \
 
 The [cert-installer](https://github.com/galasa-dev/helm/tree/main/charts/cert-installer) Helm chart exists to automate the installation of `Issuer` and `Certificate` resources on Kubernetes. See the chart's [README](https://github.com/galasa-dev/helm/blob/main/charts/cert-installer/README.md) for instructions on how to use it.
 
+To quickly apply any changes to a values.yaml file used for any of the namespaces that cert-installer is installed in, run the following command:
+
+```
+helm upgrade --values /path/to/cert-installer-values.yaml <helm-install-name> /path/to/cert-installer --namespace <namespace>
+```
+
+where:
+- `/path/to/cert-installer-values.yaml` is the file path to the values.yaml file that you wish to apply
+- `<helm-install-name>` is the name of the Helm chart's installation. You can run `helm list --namespace <namespace>` to get a list of Helm installations in a given namespace.
+- `/path/to/cert-installer` is the path to the cert-installer Helm chart (this will be in the Galasa Helm repo)
+-  `<namespace>` is the namespace in which the Helm chart was installed in
+
 Namespaces in which cert-installer has been installed in:
 
-- argocd
-- galasa-ecosystem1
-- galasa2
+- argocd (Helm install name: `argocd-tls`)
+- galasa-ecosystem1 (Helm install name: `ecosystem1-tls`)
+- galasa2 (Helm install name: `galasa2-tls`)
 
 ## Issuing a certificate manually
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2373

## Changes
- Added a YAML file of values passed to the cert-installer Helm chart to issue a certificate for argocd.galasa.dev
- Replaced the TLS secret used in the argocd ingress with the secret created by cert-manager