### PR TITLE
Update EventListener list + documentation

### DIFF
--- a/build-images/github-webhook-monitor/config.yaml
+++ b/build-images/github-webhook-monitor/config.yaml
@@ -15,4 +15,4 @@ data:
       push:
         eventListener: ["http://el-github-main-builder-listener.galasa-build.svc.cluster.local:8080"]
       workflow_run:
-        eventListener: ["http://el-github-webui-workflow-completed-listener.galasa-build.svc.cluster.local:8080","http://el-github-galasa-monorepo-workflow-completed-listener.galasa-build.svc.cluster.local:8080","http://el-github-cli-workflow-completed-listener.galasa-build.svc.cluster.local:8080"]
+        eventListener: ["http://el-github-webui-workflow-completed-listener.galasa-build.svc.cluster.local:8080","http://el-github-galasa-monorepo-workflow-completed-listener.galasa-build.svc.cluster.local:8080"]

--- a/pipelines/event-listeners/ingress.yaml
+++ b/pipelines/event-listeners/ingress.yaml
@@ -51,13 +51,3 @@ spec:
               number: 8080
         path: /galasa-monorepo-workflow
         pathType: Prefix
-  - host: triggers.galasa.dev
-    http:
-      paths:
-      - backend:
-          service:
-            name: el-github-cli-workflow-completed-listener
-            port:
-              number: 8080
-        path: /cli-workflow
-        pathType: Prefix

--- a/pipelines/event-listeners/ingress.yaml
+++ b/pipelines/event-listeners/ingress.yaml
@@ -12,14 +12,13 @@ metadata:
     kubernetes.io/ingress.class: "public-iks-k8s-nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
-  tls:
-  - hosts:
-    - triggers.galasa.dev
-    # secretName: galasa-wildcard-cert
-    secretName: unknown-secret
-    # Testing a theory that 1) galasa-wildcard-cert doesn't exist so
-    # 2) this tls section does not need to reference an existing secret
-    # so 3) does this Ingress break if we set secretName to something random?
+  # Testing a theory that the tls section is not needed as this 
+  # Ingress is only used for internal cluster traffic over HTTP
+  # therefore it does not need TLS configuration to a certificate.
+  # tls:
+  # - hosts:
+  #   - triggers.galasa.dev
+  #   secretName: unknown-secret
   rules:
   - host: triggers.galasa.dev
     http:

--- a/pipelines/event-listeners/main-builds.yaml
+++ b/pipelines/event-listeners/main-builds.yaml
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# This EventListener gets called when pushes are made to the 'main'
+# branch of the https://github.com/galasa-dev/automation repository.
+
+# It calls the Tekton Pipeline 'branch-automation'. This pipeline's
+# job is to apply CPS properties from a file checked into the repo
+# to the prod1 Galasa service's CPS with `galasactl resources apply`
+
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:

--- a/pipelines/event-listeners/monorepo-workflow-completed.yaml
+++ b/pipelines/event-listeners/monorepo-workflow-completed.yaml
@@ -4,6 +4,16 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# This EventListener gets called when there is a 'Main Build Orchestrator'
+# workflow run that has completed successfully in the 'galasa' repository.
+
+# It calls the Tekton Pipeline 'recycle-prod1' which is responsible for 
+# recycling the Deployments of the prod1 Galasa service.
+
+# It also calls the Tekton Pipeline 'build-internal-integratedtests' which
+# builds the integration tests for Galasa Managers which require internal 
+# resources (z/OS, CICS etc) and publishes these to a remote maven repo.
+
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:

--- a/pipelines/event-listeners/webui-workflow-completed.yaml
+++ b/pipelines/event-listeners/webui-workflow-completed.yaml
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# This EventListener gets called when there is a successful, completed
+# workflow run of the 'Main build' on the 'webui' repository.
+
+# It calls the Tekton Pipeline 'recycle-prod1' which is responsible for 
+# recycling the Deployments of the prod1 Galasa service.
+
 apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:


### PR DESCRIPTION
## Changes

- Removing EventListener URL `http://el-github-cli-workflow-completed-listener.galasa-build.svc.cluster.local:8080` from github-monitor ConfigMap and triggers-ingress Ingress as there is no longer a matching EventListener CRD, as we no longer care about completed CLI workflows (CLI repo is archived).

- Comments added to the remaining EventListener CRDs to explain what calls them and their purpose.

- Experimental change made to the triggers-ingress: testing if it works without a `tls` section in the CRD as the current `tls` section references a non-existent secret anyway.
