### PR TITLE
Use cert-installer to issue certificates for development.galasa.dev and rest.galasa.dev, update remaining CPS properties for ecosystem1 to 0.44.0

### DIFF
--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/codecoverage/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/codecoverage/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/isolated/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/isolated/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/javadoc-site/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/javadoc-site/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/javadoc/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/javadoc/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/mvp/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/mvp/ingress.yaml
@@ -18,7 +18,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/obr/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/obr/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/restapidoc-site/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/branch-maven-repository/templates/restapidoc-site/ingress.yaml
@@ -17,7 +17,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/cert-installer-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/cert-installer-values.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# A list of DNS names to issue a certificate for
+# For example, to issue a certificate for 'myservice.galasa.dev', the value would look like:
+#
+# dnsNames:
+#   - myservice.galasa.dev
+#
+dnsNames:
+  - development.galasa.dev
+
+# The name of the ingress class that you are using for your exposed Ingress resources.
+# Different cloud providers may offer their own ingress classes. For example, IBM Cloud
+# offers 'public-iks-k8s-nginx' and 'private-iks-k8s-nginx' classes.
+ingressClassName: public-iks-k8s-nginx
+
+# Determines whether the Issuer resource should use a production URL to issue certificates.
+# When `useIssuerProductionUrl` is false, the ACME staging URL will be used (https://acme-staging-v02.api.letsencrypt.org/directory).
+# When `useIssuerProductionUrl` is true, the ACME production URL will be used (https://acme-v02.api.letsencrypt.org/directory).
+# This value should only be set to true once you have made sure that certificates can be issued successfully using the staging URL.
+useIssuerProductionUrl: true
+
+# The email that should receive messages from Let's Encrypt about expiring certificates
+# and any issues associated with your account.
+#
+# Note: There is no mechanism to load an email from a secret, so one has been set on installation.
+# Run "kubectl describe issuer devgalasa-tls-letsencrypt-prod" to get the email that has been set.
+email: ""

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/cli/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/cli/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/galasabld/templates/ingress.yaml
@@ -15,7 +15,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/github-webhook-receiver/github-webhook-receiver-ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/github-webhook-receiver/github-webhook-receiver-ingress.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/inttests/values.yaml
@@ -17,4 +17,4 @@ ingress:
   tls:
   - hosts:
       - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/ivts/values.yaml
@@ -17,4 +17,4 @@ ingress:
   tls:
   - hosts:
       - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret

--- a/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/templates/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-development/simplatform/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
   tls:
   - hosts:
     - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    secretName: devgalasa-tls-secret
   rules:
   - host: development.galasa.dev
     http:

--- a/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-ecosystem1/galasa-ecosystem1-resources.yaml
@@ -18,7 +18,7 @@ metadata:
     namespace: framework
     name: test.stream.ivts.location
 data:
-    value: https://development.galasa.dev/main/maven-repo/ivts/dev/galasa/dev.galasa.ivts.obr/0.43.0/dev.galasa.ivts.obr-0.43.0-testcatalog.json
+    value: https://development.galasa.dev/main/maven-repo/ivts/dev/galasa/dev.galasa.ivts.obr/0.44.0/dev.galasa.ivts.obr-0.44.0-testcatalog.json
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
@@ -26,7 +26,7 @@ metadata:
     namespace: framework
     name: test.stream.ivts.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.ivts.obr/0.43.0/obr
+    value: mvn:dev.galasa/dev.galasa.ivts.obr/0.44.0/obr
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/cert-installer-values.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/cert-installer-values.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# A list of DNS names to issue a certificate for
+# For example, to issue a certificate for 'myservice.galasa.dev', the value would look like:
+#
+# dnsNames:
+#   - myservice.galasa.dev
+#
+dnsNames:
+  - rest.galasa.dev
+
+# The name of the ingress class that you are using for your exposed Ingress resources.
+# Different cloud providers may offer their own ingress classes. For example, IBM Cloud
+# offers 'public-iks-k8s-nginx' and 'private-iks-k8s-nginx' classes.
+ingressClassName: public-iks-k8s-nginx
+
+# Determines whether the Issuer resource should use a production URL to issue certificates.
+# When `useIssuerProductionUrl` is false, the ACME staging URL will be used (https://acme-staging-v02.api.letsencrypt.org/directory).
+# When `useIssuerProductionUrl` is true, the ACME production URL will be used (https://acme-v02.api.letsencrypt.org/directory).
+# This value should only be set to true once you have made sure that certificates can be issued successfully using the staging URL.
+useIssuerProductionUrl: true
+
+# The email that should receive messages from Let's Encrypt about expiring certificates
+# and any issues associated with your account.
+#
+# Note: There is no mechanism to load an email from a secret, so one has been set on installation.
+# Run "kubectl describe issuer restapidoc-tls-letsencrypt-prod" to get the email that has been set.
+email: ""

--- a/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/ingress.yaml
+++ b/infrastructure/galasa-plan-b-lon02/galasa-production/galasa-production/ingress.yaml
@@ -13,44 +13,11 @@ metadata:
 spec:
   tls:
   - hosts:
-    - resources.galasa.dev
-    - javadoc.galasa.dev
-    - javadoc-snapshot.galasa.dev
     - rest.galasa.dev
-    - development.galasa.dev
-    secretName: galasa-wildcard-cert
+    # - development.galasa.dev
+    secretName: restapidoc-tls-secret
   rules:
  
-  - host: javadoc.galasa.dev
-    http:
-      paths:
-      - backend:
-          service:
-            name: javadoc-stable
-            port:
-              number: 80
-        path: /
-        pathType: ImplementationSpecific
-  - host: javadoc-snapshot.galasa.dev
-    http:
-      paths:
-      - backend:
-          service:
-            name: javadoc-snapshot
-            port:
-              number: 80
-        path: /
-        pathType: ImplementationSpecific
-  - host: resources.galasa.dev
-    http:
-      paths:
-      - backend:
-          service:
-            name: resources
-            port:
-              number: 80
-        path: /
-        pathType: ImplementationSpecific
   - host: rest.galasa.dev
     http:
       paths:
@@ -62,14 +29,15 @@ spec:
         path: /
         pathType: ImplementationSpecific
 
-  - host: development.galasa.dev
-    http:
-      paths:
-      - backend:
-          service:
-            name: githubappcopyright
-            port:
-              number: 3000
-        path: /githubapp/copyright/event_handler
-        pathType: ImplementationSpecific
-
+  # Commented-out as the GitHub copyright app is not in use and is not functional at the moment.
+  # Should it be re-instated in the future, this Ingress path may be useful as a reference point.
+  # - host: development.galasa.dev
+  #   http:
+  #     paths:
+  #     - backend:
+  #         service:
+  #           name: githubappcopyright
+  #           port:
+  #             number: 3000
+  #       path: /githubapp/copyright/event_handler
+  #       pathType: ImplementationSpecific

--- a/infrastructure/galasa-plan-b-lon02/readme.md
+++ b/infrastructure/galasa-plan-b-lon02/readme.md
@@ -50,9 +50,13 @@ where:
 
 Namespaces in which cert-installer has been installed in:
 
-- argocd (Helm install name: `argocd-tls`)
-- galasa-ecosystem1 (Helm install name: `ecosystem1-tls`)
-- galasa2 (Helm install name: `galasa2-tls`)
+| Namespace | Helm install name | TLS secret name | Notes |
+|-----------|-------------------|-----------------|-------|
+| argocd | argocd-tls | argocd-tls-secret | Used to make ArgoCD accessible |
+| galasa2 | galasa2-tls | galasa2-tls-secret | Not in active use. Available for development and testing purposes |
+| galasa-development | devgalasa-tls | devgalasa-tls-secret | Used by the development.galasa.dev services |
+| galasa-ecosystem1 | ecosystem1-tls | ecosystem1-tls-secret | Used by the galasa-ecosystem1.galasa.dev service |
+| galasa-production | restapidoc-tls | restapidoc-tls-secret | This entry should be removed once rest.galasa.dev is being served as part of the galasa.dev docs |
 
 ## Issuing a certificate manually
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2376

## Changes
- Services exposed using development.galasa.dev and rest.galasa.dev now use a certificate created using the cert-installer helm chart
- Bumped some remaining CPS properties for the ivts test stream applied to the ecosystem1 service to 0.44.0 - Will raise a separate PR to add these into the existing set-version script