### PR TITLE
Update triggers.galasa.dev doc

### DIFF
--- a/pipelines/event-listeners/ingress.yaml
+++ b/pipelines/event-listeners/ingress.yaml
@@ -12,13 +12,9 @@ metadata:
     kubernetes.io/ingress.class: "public-iks-k8s-nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
 spec:
-  # Testing a theory that the tls section is not needed as this 
-  # Ingress is only used for internal cluster traffic over HTTP
-  # therefore it does not need TLS configuration to a certificate.
-  # tls:
-  # - hosts:
-  #   - triggers.galasa.dev
-  #   secretName: unknown-secret
+  # No tls section required for this Ingress it is only used for 
+  # internal cluster traffic over HTTP therefore it does not need 
+  # TLS configuration to a certificate.
   rules:
   - host: triggers.galasa.dev
     http:

--- a/pipelines/event-listeners/triggers.galasa.dev.md
+++ b/pipelines/event-listeners/triggers.galasa.dev.md
@@ -13,15 +13,15 @@ All deliveries to the triggers.galasa.dev Webhook have the following warning:
 We couldn't deliver this payload: tls: failed to verify certificate: x509: certificate is valid for *.galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud, galasa-plan-b-lon02-3fdc13787e8248a7d32fa4e5af5b0294-0000.eu-gb.containers.appdomain.cloud, gal...
 ```
 
-We theorise that this is because it cannot find a certificate for triggers.galasa.dev and so it defaults to the default TLS certificate provided by IBM Cloud (this is because the triggers-ingress described below is handled by the "public-iks-k8s-nginx" ingress controller). This warning is irrelevant however as the POST requests about the events are not processed directly. The [github-webhook-monitor](../../build-images/github-webhook-monitor/cmd/main.go) sends a GET request to https://api.github.com/orgs/galasa-dev/hooks/386623630/deliveries?per_page=50 and then processes the event deliveries itself.
+This is because triggers.galasa.dev does not have a TLS certificate and so it defaults to the default TLS certificate provided by IBM Cloud (this is because the `triggers-ingress` described below is handled by the "public-iks-k8s-nginx" ingress controller). This warning is irrelevant however as the POST requests about the events are not processed directly so it doesn't matter that the payload cannot be delivered. The [github-webhook-monitor](../../build-images/github-webhook-monitor/cmd/main.go) sends a GET request to https://api.github.com/orgs/galasa-dev/hooks/386623630/deliveries?per_page=50 and then processes the event deliveries itself.
 
 The ConfigMap [githubmonitor-configmap](../../build-images/github-webhook-monitor/config.yaml) is used to route the different events to a particular EventListener. Events are sent to one of two EventListeners based on what the event type is, `push` or `workflow_run`. The EventListeners then call Tekton Pipelines.
 
-Note that in the [githubmonitor-configmap](../../build-images/github-webhook-monitor/config.yaml), the EventListener URLs protocol is HTTP and therefore triggers.galasa.dev is responsible only for internal-cluster traffic, therefore it may be possible to remove its certificate entirely.
+Note that in the [githubmonitor-configmap](../../build-images/github-webhook-monitor/config.yaml), the EventListener URLs protocol is HTTP and therefore triggers.galasa.dev is responsible only for internal-cluster traffic, hence why it does not need a TLS certificate.
 
 ## Kubernetes resources
 
-On the internal **cicsk8s** Kubernetes cluster, there is a Custom Resource Definition for an Ingress, `triggers-ingress`, that configures how external traffic gets routed to services running inside the cluster.
+On the **cicsk8s** Kubernetes cluster, there is a Custom Resource Definition for an Ingress, `triggers-ingress`, that configures how traffic gets routed to services running inside the cluster. This traffic comes from inside the cluster from the github-monitor. Therefore, HTTPS is not configured for this Ingress as triggers.galasa.dev is responsible only for internal-cluster traffic.
 
 The Ingress has several rules, which define how traffic should be routed based on hostnames and paths.
 
@@ -39,4 +39,3 @@ Example rule:
       pathType: Prefix
 ```
 
-HTTPS is configured for this Ingress. The TLS certificate covers the `triggers.galasa.dev` domain, and the Kubernetes Secret containing the TLS certificate + private key is set to `galasa-wildcard-cert` **however** this Secret does not exist. Requests to https://triggers.galasa.dev are meant to use that TLS cert however it cannot be found on the cluster. As mentioned above, triggers.galasa.dev may not require a certificate at all due to its usage.


### PR DESCRIPTION
## Why?

We have now improved with the experimental PRs #730 and #731 that the `triggers-ingress` does not need a certificate as it only routes traffic internal to the cluster, and therefore it does not need a `tls` section either.

Removed the `tls` section from the Ingress CRD but added a comment to explain why and have updated the doc about this domain with the details from the investigation.