### PR TITLE
Update git-clone Task image

### DIFF
--- a/pipelines/tasks/git-clone.yaml
+++ b/pipelines/tasks/git-clone.yaml
@@ -105,7 +105,7 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that this Task runs.
       type: string
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
+      default: "ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
     - name: userHome
       description: |
         Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden


### PR DESCRIPTION
## Why?

The Tekton project has moved their images including the `git-init` image used in our `git-clone` Task from gcr.io in favour of ghcr.io (see https://github.com/tektoncd/pipeline/issues/8870#issuecomment-3057843599)

This PR updates the image used in `git-clone` to the new location in ghcr.io to fix the sporadic 403 errors we have been seeing today.