### PR TITLE
CA and self signed cert for ALB health in galasa-kube1

### DIFF
--- a/infrastructure/galasa-kube1/argocd/argocd-cm.yaml
+++ b/infrastructure/galasa-kube1/argocd/argocd-cm.yaml
@@ -39,8 +39,8 @@ data:
       id: github
       name: github.com
       config:
-        clientID: $argocd-secret:dex.github.clientid
-        clientSecret: $argocd-secret:dex.github.clientsecret
+        clientID: $dex.github.clientid
+        clientSecret: $dex.github.clientsecret
         orgs:
         - name: galasa-dev
           teams:

--- a/infrastructure/galasa-kube1/argocd/readme.md
+++ b/infrastructure/galasa-kube1/argocd/readme.md
@@ -7,7 +7,7 @@
 ### Installation instructions
 
 1. Follow the instructions on the ArgoCD [docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/user-management/#1-register-the-application-in-the-identity-provider) and create a new OAuth application on GitHub [here](https://github.com/organizations/galasa-dev/settings/applications/new). Ensure to take note of the Client ID and Client Secret.
-2. Use the Client ID and Client Secret from the OAuth app to create a Kubernetes Secret with two fields: `dex.github.clientid` and `dex.github.clientsecret`. See [secret-argocd.yaml](secret-argocd.yaml).
+2. Use the Client ID and Client Secret from the OAuth app to create a Kubernetes Secret with two fields: `dex.github.clientid` and `dex.github.clientsecret`.
 3. Create a namespace `argocd`: `kubectl create namespace argocd`
 4. Apply [argocd.yaml](./argocd.yaml) **once** into the `argocd` namespace: `kubectl apply -f argocd.yaml -n argocd`
 5. Apply [argocd-cm.yaml](./argocd-cm.yaml) into the `argocd` namespace: `kubectl apply -f argocd-cm.yaml -n argocd`
@@ -32,20 +32,6 @@
 
 
 ## Useful commands 
-
-If you need to refresh the secret files, you have to delete them first:
-
-```
-kubectl delete -f infrastructure/galasa-kube1/argocd/secret-argocd.yaml
-kubectl delete -f infrastructure/galasa-kube1/argocd/secrets-manager.yaml
-
-kubectl apply -f infrastructure/galasa-kube1/argocd/secrets-manager.yaml
-kubectl apply -f infrastructure/galasa-kube1/argocd/secret-argocd.yaml
-```
-
-```
-kubectl get ExternalSecrets  
-```
 
 ```
 kubectl rollout restart -n argocd deployments argocd-applicationset-controller argocd-dex-server argocd-notifications-controller argocd-redis argocd-repo-server argocd-server

--- a/infrastructure/galasa-kube1/cluster-issuer.yaml
+++ b/infrastructure/galasa-kube1/cluster-issuer.yaml
@@ -3,7 +3,9 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-apiVersion: v1
-kind: Namespace
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
 metadata:
-  name: secrets-manager
+  name: alb-internal-ca
+spec:
+  selfSigned: {}

--- a/infrastructure/galasa-kube1/kube-system/alb-health-cert.yaml
+++ b/infrastructure/galasa-kube1/kube-system/alb-health-cert.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: alb-health-tls-cert
+  namespace: kube-system
+spec:
+  secretName: alb-health-tls-secret
+  issuerRef:
+    name: alb-internal-ca
+    kind: ClusterIssuer
+  dnsNames:
+    - albhealth.galasa-kube1-d2e8765deb38dddd0aa1b649462cf87f-0000.eu-gb.containers.appdomain.cloud

--- a/infrastructure/galasa-kube1/secret-manager-operator/readme.md
+++ b/infrastructure/galasa-kube1/secret-manager-operator/readme.md
@@ -1,1 +1,0 @@
-This namespace is required to install the External Secrets Operator CRDs.


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2548

## Changes

- [x] Creates an internal CA and self-signed certificate for the ALB health check endpoints within the galasa-kube1 cluster
- [x] The secret created containing the certificate has been patched into the ALB health check Ingresses
- [x] Update the reference to the argocd-secret in the argocd-cm
- [x] Delete references to the now deleted file secret-argocd.yaml
- [x] Delete leftover readme.md about the secrets-manager-operator