### PR TITLE
Remove perl from the base image as it is not needed

### DIFF
--- a/dockerfiles/base/base.Dockerfile
+++ b/dockerfiles/base/base.Dockerfile
@@ -1,4 +1,7 @@
 FROM ghcr.io/galasa-dev/httpd:alpine
 
-RUN rm -v /usr/local/apache2/htdocs/*
+
+# Mend scans reported vulnerabilities with perl, which gets installed in the httpd image.
+# perl is an optional requirement for httpd, so we're removing it here.
+RUN rm -v /usr/local/apache2/htdocs/* && apk --purge del perl
 COPY dockerfiles/httpdconf/base-httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/dockerfiles/base/base.Dockerfile
+++ b/dockerfiles/base/base.Dockerfile
@@ -1,6 +1,5 @@
 FROM ghcr.io/galasa-dev/httpd:alpine
 
-
 # Mend scans reported vulnerabilities with perl, which gets installed in the httpd image.
 # perl is an optional requirement for httpd, so we're removing it here.
 RUN rm -v /usr/local/apache2/htdocs/* && apk --purge del perl


### PR DESCRIPTION
## Why?
Refer to https://github.com/galasa-dev/projectmanagement/issues/2568

## Changes
- [x] Removed perl from the base Docker image as Mend scans have reported vulnerabilities in perl 5.42.0 (which is what httpd:alpine currently uses). Perl is an optional requirement for httpd (see https://httpd.apache.org/docs/2.4/install.html#requirements), and we don't use any support scripts for the download site.
  - This has been tested locally and the download site works like it did when perl was installed