### PR TITLE
fix: Fix isolated image tags in release docs, use gh CLI to delete helm pre-releases

### DIFF
--- a/releasePipeline/05-helm-charts.sh
+++ b/releasePipeline/05-helm-charts.sh
@@ -218,28 +218,16 @@ function delete_pre_release_helm_charts {
 
         release_tag=$chart-$galasa_version
 
-        # get the release using the tag name and pull out the release url to delete
-        release_json_details="temp/$release_tag.txt"
-        release_by_tag_url="https://api.github.com/repos/galasa-dev/helm/releases/tags/$release_tag"
-        curl $release_by_tag_url > $release_json_details -s
-        release_url=$(grep -Ei ' *"url" *: *"(https:\/\/api\.github\.com\/repos\/galasa-dev\/helm\/releases\/[0-9]*)"' $release_json_details | cut -d \" -f 4)
-
         # Delete pre-release github release
-        response_code=$(curl -X DELETE $release_url -w "${response_code}")
-        if [[ "${response_code}" != "204" ]]; then 
-            error "Unable to delete release for $release_tag using the api url '$release_url'. Expected status code '204' and got '$response_code'."
-            exit 1
+        delete_command="gh release delete galasa-dev/helm/$release_tag --cleanup-tag"
+        info "Delete release for $release_tag using the command $delete_command."
+        $delete_command
+        rc=$?
+        if [[ "${rc}" != "0" ]]; then
+            error "Failed to delete release with tag $release_tag. rc=${rc}. You must manually delete the release and the associated tag at https://github.com/galasa-dev/helm/releases"
+        else
+            success "Deleted release for $release_tag OK."
         fi
-        success "Delete release for $release_tag using the api url '$release_url'."
-        # Delete pre-release tag
-        tag_url="https://api.github.com/repos/galasa-dev/helm/tags/$release_tag"
-        response_code= $(curl -X DELETE $url -w "%{response_code}")
-        if [[ "${response_code}" != "204" ]]; then 
-            error "Unable to delete tag $release_tag using the api url '$tag_url'. Expected status code '204' and got '$response_code'."
-            exit 1
-        fi
-        success "Delete release for $release_tag using the api url '$tag_url'."
-
     done
 }
 

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -59,7 +59,7 @@ The steps below are to ensure the MVP zip works as described in the documentatio
 
 1. Download the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp).
 2. Unpack the zip and go to the folder in the command line.
-3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:main`. This is to ensure that the isolated.tar which is provided in the MVP can be successfully untarred and loads a Docker image. 
-4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:main`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
+3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:prerelease`. This is to ensure that the isolated.tar which is provided in the MVP can be successfully untarred and loads a Docker image. 
+4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:prerelease`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
 5. Follow the instructions on the [Exploring Galasa SimBank offline](https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
     - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed)

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -50,8 +50,8 @@ The steps below are to ensure the MVP zip works as described in the documentatio
 
 1. Download the [MVP zip](https://development.galasa.dev/release/maven-repo/mvp/dev/galasa/galasa-isolated-mvp).
 2. Unpack the zip and go to the folder in the command line.
-3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:main`. This is to ensure that the isolated.tar can be successfully untarred and loads a Docker image. 
-4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:main`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
+3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:release`. This is to ensure that the isolated.tar can be successfully untarred and loads a Docker image. 
+4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:release`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
 5. Follow the instructions on the [Exploring Galasa SimBank offline](https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
     - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed)
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2528

## Changes
- [x] Instructions to load the isolated Docker image in prerelease.md and release.md previously mentioned the `main` tag - they now correctly mention `prerelease` and `release` tags
- [x] Updated the 05-helm-charts script to use the `gh` CLI tool to delete pre-releases in the helm repo as the existing REST API requests would always fail with unauthorized errors (note: this may need further adjustments as this change was done after the pre-release process had completed)