### PR TITLE
Replace mentions of galasa-service1 with galasa-service-main, parameterise helm workflow

### DIFF
--- a/.github/workflows/apply-galasa-resources.yaml
+++ b/.github/workflows/apply-galasa-resources.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-name: Apply Galasa Resources for 'galasa-service1'
+name: Apply Galasa Resources for 'galasa-service-main'
 
 on:
   push:
@@ -15,7 +15,7 @@ env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
-  # This workflow applies the Galasa resources YAML file used by the 'galasa-service1' Galasa service.
+  # This workflow applies the Galasa resources YAML file used by the 'galasa-service-main' Galasa service.
   apply-galasa-resources:
     name: Apply Galasa resources YAML file
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
-            infrastructure/galasa-kube1/galasa-service1/galasa-service1-resources.yaml
+            infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
           sparse-checkout-cone-mode: false
 
       - name: Ensure permissions for mounted /galasa directory
@@ -47,17 +47,17 @@ jobs:
       - name: Run the 'galasactl resources apply' command
         env:
           GALASA_HOME: /galasa
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE1 }}
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
           GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
         run: |
           docker run --rm \
           --env GALASA_HOME=${{ env.GALASA_HOME }} \
           --env GALASA_TOKEN=${{ env.GALASA_TOKEN }} \
           --user galasa:galasa \
-          -v ${{ github.workspace }}/infrastructure/galasa-kube1/galasa-service1/galasa-service1-resources.yaml:/var/workspace/galasa-service1-resources.yaml \
+          -v ${{ github.workspace }}/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml:/var/workspace/galasa-service-main-resources.yaml \
           -v ${{ github.workspace }}/galasa:/galasa:rw \
           ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
           galasactl resources apply \
           --bootstrap ${{ env.GALASA_SERVICE_BOOTSTRAP_URL }} \
-          --file /var/workspace/galasa-service1-resources.yaml \
+          --file /var/workspace/galasa-service-main-resources.yaml \
           --log -

--- a/.github/workflows/build-helm.yaml
+++ b/.github/workflows/build-helm.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-name: Helm build (galasa-service1)
+name: Helm build
 
 on:
   workflow_dispatch:
@@ -11,12 +11,14 @@ on:
 env:
   NAMESPACE: galasa-dev
   BRANCH: ${{ github.ref_name }}
+  GALASA_SERVICE_HELM_NAME: ${{ vars.GALASA_SERVICE_HELM_NAME }}
+  GALASA_SERVICE_VALUES_FILE_PATH: ${{ vars.GALASA_SERVICE_VALUES_FILE_PATH }}
 
 jobs:
   build-helm:
     # Skip this job for forks
     if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Build Helm chart for galasa-service1
+    name: Install Helm chart for the external Galasa service
     runs-on: ubuntu-latest
 
     steps:
@@ -42,19 +44,19 @@ jobs:
           mkdir -p $HOME/.kube
           echo "${{ env.KUBE_CONFIG_PLAN_B_CLUSTER }}" >> $HOME/.kube/config
       
-      - name: Uninstall galasa-service1
+      - name: Uninstall existing Galasa service
         run: |
-          helm uninstall main-service --ignore-not-found --namespace=galasa-service1 --kubeconfig $HOME/.kube/config
+          helm uninstall ${{ env.GALASA_SERVICE_HELM_NAME }} --ignore-not-found --namespace=galasa-service1 --kubeconfig $HOME/.kube/config
       
       # Default timeout is 5m0s. Stating that explicitly so we can change it easily.
       # The install takes a long time because we are waiting for all the pods to start up.
-      - name: Install galasa-service1
+      - name: Install Galasa service
         run: |
-          helm install main-service ${{ github.workspace }}/helm/charts/ecosystem --namespace=galasa-service1 --values ${{ github.workspace }}/infrastructure/galasa-kube1/galasa-service1/helm-values.yaml --kubeconfig $HOME/.kube/config --timeout 10m0s --wait
+          helm install ${{ env.GALASA_SERVICE_HELM_NAME }} ${{ github.workspace }}/helm/charts/ecosystem --namespace=galasa-service1 --values ${{ github.workspace }}/${{ env.GALASA_SERVICE_VALUES_FILE_PATH }} --kubeconfig $HOME/.kube/config --timeout 10m0s --wait
 
-      - name: Test galasa-service1
+      - name: Test Galasa service
         run: |
-          helm test main-service --namespace=galasa-service1 --kubeconfig $HOME/.kube/config
+          helm test ${{ env.GALASA_SERVICE_HELM_NAME }} --namespace=galasa-service1 --kubeconfig $HOME/.kube/config
 
   trigger-next-workflow:
     # Skip this job for forks

--- a/.github/workflows/regression-tests-core-non-zos.yaml
+++ b/.github/workflows/regression-tests-core-non-zos.yaml
@@ -35,13 +35,13 @@ jobs:
           ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
           rm -rf /galasa/*
 
-      # Only include the non-zos tests that can run on galasa-service1.
+      # Only include the non-zos tests that can run on galasa-service-main.
       # This currently excludes the `dev.galasa.ivts.docker` and `dev.galasa.ivts.compilation` tests
       # as they require a remote Docker engine to be available.
       - name: Prepare test portfolio for 'ivts' test stream
         env:
           GALASA_HOME: /galasa
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE1 }}
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
           GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
         run: |
           docker run --rm \
@@ -62,7 +62,7 @@ jobs:
       - name: Submit test portfolio for 'ivts' test stream
         env:
           GALASA_HOME: /galasa
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE1 }}
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
           GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
         run: |
           docker run --rm \
@@ -93,6 +93,6 @@ jobs:
           ghcr.io/${{ env.NAMESPACE }}/galasabld-ibm:main \
           slackpost tests \
           --path /galasa/test.json \
-          --name "Core tests - galasa-service1" \
+          --name "Core tests - galasa-service-main" \
           --desc "Core, HTTP, Artifact etc" \
           --hook ${{ env.SLACK_WEBHOOK }}

--- a/.github/workflows/run-core-test.yaml
+++ b/.github/workflows/run-core-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Run the 'CoreManagerIVT'
         env:
           GALASA_HOME: /galasa
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE1 }}
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
           GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
         run: |
           docker run --rm \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Find out more about:
 This directory contains GitHub Actions workflows. Runs of these workflows can be found in the [Actions tab](https://github.com/galasa-dev/automation/actions) of this repository.
 
 apply-galasa-resources:
-Uses `galasactl resources apply` to apply changes to the file [galasa-service1-resources.yaml](./infrastructure/galasa-kube1/galasa-service1/galasa-service1-resources.yaml) to galasa-service1's CPS properties.
+Uses `galasactl resources apply` to apply changes to the file [galasa-service-main-resources.yaml](./infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml) to galasa-service-main's CPS properties.
 
 base-image:
 Builds and pushes the Galasa base httpd image to GHCR. Should be triggered if changes are made to the [base Dockerfile](./dockerfiles/base/base.Dockerfile).
@@ -32,10 +32,10 @@ pr-build-automation:
 This workflow runs if a Pull Request is opened on this reposutory. It builds the custom Docker images whose Dockerfiles can be found in the [dockerfiles/common](./dockerfiles/common/) directory to make sure they build successfully.
 
 regression-tests-core-non-zos:
-This workflow runs daily and regression tests a selection of the Galasa Managers that do not exercise z/OS so these tests can be run on the external galasa-service1.
+This workflow runs daily and regression tests a selection of the Galasa Managers that do not exercise z/OS so these tests can be run on the external galasa-service-main.
 
 run-core-test:
-Runs the test CoreManagerIVT on galasa-service1 for the purpose of verifying the service health.
+Runs the test CoreManagerIVT on galasa-service-main for the purpose of verifying the service health.
 
 sync-docker-proxy:
 Runs weekly to sync images stored in Galasa's [GitHub Packages](https://github.com/orgs/galasa-dev/packages) with any updates from Docker Hub.

--- a/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
+++ b/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-# The Galasa resources defined in this file are applied to the 'service1' service.
+# The Galasa resources defined in this file are applied to the 'service-main' service.
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty
 metadata:

--- a/releasePipeline/25-run-ivts.sh
+++ b/releasePipeline/25-run-ivts.sh
@@ -7,7 +7,7 @@
 #
 #-----------------------------------------------------------------------------------------                   
 #
-# Objectives: Run Core IVTs in galasa-service1.
+# Objectives: Run Core IVTs in galasa-service-main.
 #
 # Environment variable over-rides:
 # 

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -63,7 +63,7 @@ The steps below are to ensure the MVP zip works as described in the documentatio
 
 #### Tests that run from GitHub Actions
 
-Each of these scripts starts a GitHub Actions workflow. These test suites run tests from the GitHub Actions runner either locally in the runner, or they submit tests to run remotely on galasa-service1.
+Each of these scripts starts a GitHub Actions workflow. These test suites run tests from the GitHub Actions runner either locally in the runner, or they submit tests to run remotely on galasa-service-main.
 
 The script will give you the URL of the workflow run. You will have to monitor the workflow run in GitHub Actions and ensure it finishes successfully and all tests pass.
 

--- a/releasePipeline/set-version.sh
+++ b/releasePipeline/set-version.sh
@@ -121,24 +121,24 @@ function update_property_version {
 function upgrade_test_stream_ivts_location_version {
     property_name="test.stream.ivts.location"
     prod1_properties_file="${WORKSPACE_DIR}/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml"
-    service1_properties_file="${WORKSPACE_DIR}/infrastructure/galasa-kube1/galasa-service1/galasa-service1-resources.yaml"
+    service_main_properties_file="${WORKSPACE_DIR}/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml"
     value_regex="https:\\/\\/development[.]galasa[.]dev\\/main\\/maven-repo\\/ivts\\/dev\\/galasa\\/dev[.]galasa[.]ivts[.]obr\\/[0-9.]+\\/dev[.]galasa[.]ivts[.]obr-[0-9.]+-testcatalog[.]json"
     new_value="https:\\/\\/development.galasa.dev\\/main\\/maven-repo\\/ivts\\/dev\\/galasa\\/dev.galasa.ivts.obr\\/${galasa_version}\\/dev.galasa.ivts.obr-${galasa_version}-testcatalog.json"
 
     update_property_version "${prod1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
-    update_property_version "${service1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
+    update_property_version "${service_main_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
 }
 
 # bumping version for the value of property test.stream.ivts.obr
 function upgrade_test_stream_ivts_obr_version {
     property_name="test.stream.ivts.obr"
     prod1_properties_file="${WORKSPACE_DIR}/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml"
-    service1_properties_file="${WORKSPACE_DIR}/infrastructure/galasa-kube1/galasa-service1/galasa-service1-resources.yaml"
+    service_main_properties_file="${WORKSPACE_DIR}/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml"
     value_regex="mvn:dev.galasa\\/dev[.]galasa[.]ivts[.]obr\\/[0-9.]+\\/obr"
     new_value="mvn:dev.galasa\\/dev.galasa.ivts.obr\\/${galasa_version}\\/obr"
 
     update_property_version "${prod1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
-    update_property_version "${service1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
+    update_property_version "${service_main_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
 }
 
 #bumping version for the value of property test.stream.inttests.location


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1531

Note: This PR builds off of changes in https://github.com/galasa-dev/automation/pull/772 so will need to be rebased before reviewing.

## Changes
- [x] Replaced mentions of galasa-service1 with galasa-service-main where appropriate
- [x] Parameterised the helm workflow used to re-install the helm chart on the external cluster