### PR TITLE
Add istio and gateway API permissions to the galasa-service-admin role

### DIFF
--- a/infrastructure/galasa-kube1/galasa-service1/admin-role.yaml
+++ b/infrastructure/galasa-kube1/galasa-service1/admin-role.yaml
@@ -61,6 +61,19 @@ rules:
   - "externalsecrets"
   verbs:
   - "*"
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - "httproutes"
+  verbs:
+  - "*"
+  - "*"
+- apiGroups:
+  - "security.istio.io"
+  resources:
+  - "peerauthentications"
+  verbs:
+  - "*"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1531

## Changes
- [x] Added permissions to manage `httproutes` (gateway API) and `peerauthentications` (istio) for the `galasa-service-admin` role in the galasa-service1 namespace