### PR TITLE
Iss2566 - Sync node v24.11.0-alpine to our GHCR Docker Proxy Cache

### DIFF
--- a/.github/workflows/sync-docker-proxy.yaml
+++ b/.github/workflows/sync-docker-proxy.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Pull, Retag, and Push Images
         run: |
-          IMAGES=("alpine:3.18.4" "alpine:3.18.5" "alpine:3.18.6" "bash:3.2.57" "busybox:1.32.0" "busybox:1.36.1" "golang:1.20.1" "gradle:8.9-jdk17" "httpd:alpine" "httpd:2.4.59" "maven:3.8.5-openjdk-17" "node:20.10.0-alpine" "openjdk:11" "openjdk:11-jdk" "openjdk:17" "ubuntu:20.04")
+          IMAGES=("alpine:3.18.4" "alpine:3.18.5" "alpine:3.18.6" "bash:3.2.57" "busybox:1.32.0" "busybox:1.36.1" "golang:1.20.1" "gradle:8.9-jdk17" "httpd:alpine" "httpd:2.4.59" "maven:3.8.5-openjdk-17" "node:24.11.0-alpine" "openjdk:11" "openjdk:11-jdk" "openjdk:17" "ubuntu:20.04")
           for IMAGE in "${IMAGES[@]}"; do
             docker pull docker.io/library/$IMAGE
             docker tag docker.io/library/$IMAGE ghcr.io/${{ env.NAMESPACE }}/$IMAGE


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2566

Needed for the changes made in https://github.com/galasa-dev/webui/pull/289

We are uplifting the node version due to GitHub's deprecation warnings about node v20.

## Changes
- [x] Uplift the version of the node's Docker image that we sync to our GHCR Docker Proxy Cache from Dockerhub to 24.11.0-alpine from 20.10.0 to allow the Galasa WebUI docker image to pull it.