### PR TITLE
Add nodeSelector for amd64 inttests-main deploy

### DIFF
--- a/infrastructure/galasa-kube1/galasa-development/inttests/templates/deployment.yaml
+++ b/infrastructure/galasa-kube1/galasa-development/inttests/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         app: inttests-{{ .Values.branch }}
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
       containers:
         - image: {{ .Values.imageName }}:{{ .Values.imageTag }}
           imagePullPolicy: Always


### PR DESCRIPTION
## Why?

The inttests-main Pod is failing to start due to an `exec format error` at the moment. This is because it keeps being assigned to nodes on the cicsk8s cluster without amd64 architecture. This nodeSelector ensures the Pod is assigned to an amd64 node.