### PR TITLE
Automation updates following the reinstall of prod1

### DIFF
--- a/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
+++ b/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
@@ -141,7 +141,7 @@ metadata:
     namespace: framework
     name: test.stream.simbank.obr
 data:
-    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.41.0/obr
+    value: mvn:dev.galasa/dev.galasa.simbank.obr/0.48.0/obr
 ---
 apiVersion: galasa-dev/v1alpha1
 kind: GalasaProperty

--- a/pipelines/pipelines/recycle-ecosystem/install-prod1.yaml
+++ b/pipelines/pipelines/recycle-ecosystem/install-prod1.yaml
@@ -1,0 +1,217 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# This pipeline installs prod1 from scratch
+# For an upgrade when already installed, use upgrade-prod1
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: install-prod1
+  namespace: galasa-build
+spec:
+#
+#
+#
+  params:
+  - name: kubeNamespace
+    type: string
+    default: galasa-dev
+  - name: galasaServiceName
+    type: string
+    default: prod1
+  - name: certificatesConfigMapName
+    type: string
+    default: ibm-certificates
+  - name: log4jJsonTemplatesConfigMapName
+    type: string
+    default: galasa-log4j-json-templates
+#
+#
+#
+  workspaces:
+  - name: git-workspace
+#
+#
+#
+  tasks:
+#
+#
+#
+  - name: clone-galasa-config
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.ibm.com/galasa/internal-config
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/internal-config
+    workspaces:
+     - name: output
+       workspace: git-workspace
+#
+#
+#
+  - name: clone-helm
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/helm
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/helm
+    workspaces:
+     - name: output
+       workspace: git-workspace
+#
+#
+#
+  - name: clone-automation
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: https://github.com/galasa-dev/automation
+    - name: revision
+      value: main
+    - name: refspec
+      value: refs/heads/main:refs/heads/main
+    - name: depth
+      value: "99999999"
+    - name: subdirectory
+      value: $(context.pipelineRun.name)/automation
+    workspaces:
+     - name: output
+       workspace: git-workspace
+#
+#
+#
+  - name: update-certificates-configmap
+    taskRef:
+      name: script
+    runAfter:
+    - clone-galasa-config
+    - clone-helm
+    - clone-automation
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/automation/dockerfiles/certs
+    - name: image
+      value: ghcr.io/galasa-dev/kubectl:main
+    - name: script
+      value: |
+        kubectl --namespace=$(params.kubeNamespace) create configmap $(params.certificatesConfigMapName) \
+        --from-file=carootcert.der \
+        --from-file=caintermediatecert.der \
+        --output=yaml \
+        --dry-run=client | kubectl apply -f -
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace 
+#
+#
+#
+  - name: update-log4j-json-layouts-configmap
+    taskRef:
+      name: script
+    runAfter:
+    - clone-galasa-config
+    - clone-helm
+    - clone-automation
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)/automation/infrastructure/cicsk8s/galasa-dev/log4j
+    - name: image
+      value: ghcr.io/galasa-dev/kubectl:main
+    - name: script
+      value: |
+        kubectl create configmap $(params.log4jJsonTemplatesConfigMapName) \
+        --namespace=galasa-dev \
+        --from-file=GalasaLogsLayout.json \
+        --output=yaml \
+        --dry-run=client | kubectl apply -f -
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace
+#
+#
+#
+  - name: install-prod1
+    taskRef:
+      name: helm
+    runAfter:
+    - update-certificates-configmap
+    - update-log4j-json-layouts-configmap
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: command
+      value:
+        - --namespace
+        - $(params.kubeNamespace)
+        - install
+        - $(params.galasaServiceName)
+        - helm/charts/ecosystem
+        - --values
+        - internal-config/prod1-helm-values.yaml
+        - --timeout
+        - 10m0s
+        - --wait
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace
+#
+#
+#
+  - name: test-prod1
+    taskRef:
+      name: helm
+    runAfter:
+    - upgrade-prod1
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: command
+      value:
+        - --namespace
+        - $(params.kubeNamespace)
+        - test
+        - $(params.galasaServiceName)
+    workspaces:
+    - name: git-workspace
+      workspace: git-workspace
+#
+#
+#
+  finally:
+  - name: report-failed-build
+    when:
+      - input: "$(tasks.status)"
+        operator: in
+        values: ["Failed"]
+    taskRef:
+      name: slack-post
+    params:
+    - name: pipelineName
+      value: $(context.pipeline.name)
+    - name: pipelineRunName
+      value: $(context.pipelineRun.name)
+    - name: branchFlag
+      value: ""
+    - name: branch
+      value: ""

--- a/releasePipeline/set-version.sh
+++ b/releasePipeline/set-version.sh
@@ -161,6 +161,16 @@ function upgrade_test_stream_inttests_obr_version {
     update_property_version "${prod1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
 }
 
+#bumping version for the value of property test.stream.simbank.obr
+function upgrade_test_stream_simbank_obr_version {
+    property_name="test.stream.simbank.obr"
+    prod1_properties_file="${WORKSPACE_DIR}/infrastructure/cicsk8s/galasa-dev/cps-properties.yaml"
+    value_regex="mvn:dev.galasa\\/dev[.]galasa[.]simbank[.]obr\\/[0-9.]+\\/obr"
+    new_value="mvn:dev.galasa\\/dev.galasa.simbank.obr\\/${galasa_version}\\/obr"
+
+    update_property_version "${prod1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
+}
+
 #bumping version for the value of property isolated.full.zip
 function upgrade_isolated_full_zip_version {
     property_name="isolated.full.zip"
@@ -246,6 +256,7 @@ upgrade_test_stream_ivts_location_version
 upgrade_test_stream_ivts_obr_version
 upgrade_test_stream_inttests_location_version
 upgrade_test_stream_inttests_obr_version
+upgrade_test_stream_simbank_obr_version
 upgrade_isolated_full_zip_version
 upgrade_isolated_mvp_zip_version
 upgrade_galasa_versions

--- a/trigger-pipeline.sh
+++ b/trigger-pipeline.sh
@@ -54,6 +54,7 @@ Options are:
 (from the 'main' build chain)
 --automation
 --update-prod1
+--install-prod1
 --test-cli
 -p | --pipeline xxx : Set the name of pipeline to run explicitly
 
@@ -88,6 +89,8 @@ while [ "$1" != "" ]; do
         --automation )              pipeline="branch-automation"
                                     ;;
         --update-prod1 )            pipeline="update-prod1"
+                                    ;;
+        --install-prod1 )           pipeline="install-prod1"
                                     ;;
         --internal-tests )          pipeline="build-internal-integratedtests"
                                     ;;


### PR DESCRIPTION
## Changes

- [x] Adds an install-prod1 Tekton pipeline and call to that Pipeline from the trigger-pipeline script, to install prod1 from scratch when not already installed.
- [x] Updates the framework.test.stream.simbank.obr property to v0.48.0 - property is not used currently but keeping it up to date as its confusing.
- [x] Adds missing function in set-version script that updates the above property.