### PR TITLE
Updates to release process

### DIFF
--- a/releasePipeline/05-helm-charts.sh
+++ b/releasePipeline/05-helm-charts.sh
@@ -219,7 +219,7 @@ function delete_pre_release_helm_charts {
         release_tag=$chart-$galasa_version
 
         # Delete pre-release github release
-        delete_command="gh release delete galasa-dev/helm/$release_tag --cleanup-tag"
+        delete_command="gh release delete $release_tag --repo galasa-dev/helm --cleanup-tag --yes"
         info "Delete release for $release_tag using the command $delete_command."
         $delete_command
         rc=$?

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -49,9 +49,7 @@ Ensure you have completed either the [automated](#pre-release-steps---automated)
 
 ### MEND scan
 
-1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) on how to do this.
-
-**Note:**
+1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) on how to do this. **Note:** the bundles `dev.galasa.wrapping.com.auth0.jwt` and `dev.galasa.wrapping.kafka.clients` are not included in the MVP, therefore if vulnerabilities are found only in these bundles, they will not affect any IBM scans. However, they should still be remediated before starting the proper release if possible.
 
 ### Test the MVP
 

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -51,6 +51,8 @@ Ensure you have completed either the [automated](#pre-release-steps---automated)
 
 1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) on how to do this.
 
+**Note:**
+
 ### Test the MVP
 
 The steps below are to ensure the MVP zip works as described in the documentation.
@@ -61,5 +63,5 @@ The steps below are to ensure the MVP zip works as described in the documentatio
 2. Unpack the zip and go to the folder in the command line.
 3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:prerelease`. This is to ensure that the isolated.tar which is provided in the MVP can be successfully untarred and loads a Docker image. 
 4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:prerelease`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
-5. Follow the instructions on the [Exploring Galasa SimBank offline](https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
+5. Follow the instructions on the [Launching the SimBank application offline](https://vnext.galasa.dev/docs/using-galasa-offline/simbank-cli-offline/) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
     - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed)

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -52,7 +52,7 @@ The steps below are to ensure the MVP zip works as described in the documentatio
 2. Unpack the zip and go to the folder in the command line.
 3. Run `docker load -i isolated.tar` and confirm that the output is `Loaded image: ghcr.io/galasa-dev/galasa-mvp:release`. This is to ensure that the isolated.tar can be successfully untarred and loads a Docker image. 
 4. If the last step was successful, run the provided Docker image by running `docker run -d -p 8080:80 --name galasa ghcr.io/galasa-dev/galasa-mvp:release`. Navigate to `localhost:8080` in a browser and confirm that the hosted version of the MVP zip appears. 
-5. Follow the instructions on the [Exploring Galasa SimBank offline](https://galasa.dev/docs/running-simbank-tests/simbank-cli-offline) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
+5. Follow the instructions on the [Launching the SimBank application offline](https://vnext.galasa.dev/docs/using-galasa-offline/simbank-cli-offline/) page of the documentation to ensure that a 3270 emulator can connect to the Simplatform application.
     - After starting the Simplatform application by running the `run-simplatform.sh` script, you can start your 3270 emulator pointing it to port 2023 of localhost by running `c3270 localhost -port 2023` (you will need the x3270 tool installed)
 
 ### MEND scan

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -81,9 +81,10 @@ The script will give you the pipeline run name. You will have to monitor the pip
 
 **These three steps should be done one after the other.**
 
-1. Run [26-run-cicsts-isolated-tests.sh](./26-run-cicsts-isolated-tests.sh). This tests that the CICS, CEMT, CEDA and SDV Managers work offline using just the Isolated zip.
-2. Run [27-run-prod1-ivts.sh](./27-run-prod1-ivts.sh). This tests that the CICS, CEMT, CEDA, SDV and z/OS Managers work online.
-3. Run [28-run-prod1-integration-tests.sh](./28-run-prod1-integration-tests.sh).
+<!-- Temporarily removing this step as these tests require a DSE CICS Region which is currently down, so these will always fail -->
+<!-- 1. Run [26-run-cicsts-isolated-tests.sh](./26-run-cicsts-isolated-tests.sh). This tests that the CICS, CEMT, CEDA and SDV Managers work offline using just the Isolated zip. -->
+1. Run [27-run-prod1-ivts.sh](./27-run-prod1-ivts.sh). This tests that the CICS, CEMT, CEDA, SDV and z/OS Managers work online.
+2. Run [28-run-prod1-integration-tests.sh](./28-run-prod1-integration-tests.sh).
 
 Some tests may fail on the first run due to the lack of system resource availability. Rerunning the test should hopefully result in a pass. Make sure that external systems the tests connect to are active and healthy (for example, @hobbit1983's CICS Region).
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2591

Minor fixes to the release process scripts and documentation from the v0.48.1 release. Full automation of the release process will be completed in a separate PR for story https://github.com/galasa-dev/projectmanagement/issues/2593

## Changes
- [x] Comment out step to run CICS TS tests with Isolated/MVP as they do not work without a DSE CICS Region (currently unavailable)
- [x] Fix `gh release delete` command with missing `--repo` flag and `--yes` flag to skip interactive confirmation
- [x] Fix incorrect link to the Simbank documentation for manual testing of the Simplatform app
- [x] Add note about what to do if vulnerabilities are found in the MEND scan for non-MVP bundles