### PR TITLE
Add CoreManagerIVT run that pulls material from the authenticated IVTs maven repo, add secure-ivts stream for galasa-service-main

### DIFF
--- a/.github/workflows/run-core-test.yaml
+++ b/.github/workflows/run-core-test.yaml
@@ -52,3 +52,24 @@ jobs:
           --poll "10" \
           --progress "1" \
           --log -
+
+      - name: Run the 'CoreManagerIVT' on the secure stream
+        env:
+          GALASA_HOME: /galasa
+          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
+          GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
+        run: |
+          docker run --rm \
+          --env GALASA_HOME=${{ env.GALASA_HOME }} \
+          --env GALASA_TOKEN=${{ env.GALASA_TOKEN }} \
+          --user galasa:galasa \
+          -v ${{ github.workspace }}/galasa:/galasa:rw \
+          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          galasactl runs submit \
+          --bootstrap ${{ env.GALASA_SERVICE_BOOTSTRAP_URL }} \
+          --stream secure-ivts \
+          --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
+          --throttle "10" \
+          --poll "10" \
+          --progress "1" \
+          --log -

--- a/.github/workflows/run-core-test.yaml
+++ b/.github/workflows/run-core-test.yaml
@@ -11,30 +11,37 @@ on:
 env:
   NAMESPACE: ${{ github.repository_owner }}
   BRANCH: ${{ github.ref_name }}
+  GALASA_CLI_IMAGE: ghcr.io/${{ github.repository_owner }}/galasactl-x86_64:main
+  GALASA_HOME: /galasa
 
 jobs:
-  # This workflow runs a single test the CoreManagerIVT to verify the health of the Galasa service.
   run-core-test:
-    name: Run CoreManagerIVT to verify Galasa service health
+    name: Run CoreManagerIVT - ${{ matrix.test-type }}
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        include:
+          - test-type: 'service-ivts'
+            stream: 'ivts'
+            test-mode: 'service'
+          - test-type: 'service-secure-ivts'
+            stream: 'secure-ivts'
+            test-mode: 'service'
 
     steps:
-      - name: Ensure permissions for mounted /galasa directory
+      - name: Setup Galasa workspace
         run: |
           sudo mkdir -p ${{ github.workspace }}/galasa
           sudo chown -R 999:999 ${{ github.workspace }}/galasa
-
-      - name: Clean /galasa workspace in CLI image
-        run: |
           docker run --rm \
           --user galasa:galasa \
           -v ${{ github.workspace }}/galasa:/galasa \
-          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          ${{ env.GALASA_CLI_IMAGE }} \
           rm -rf /galasa/*
 
-      - name: Run the 'CoreManagerIVT'
+      - name: Run CoreManagerIVT on a Galasa service
         env:
-          GALASA_HOME: /galasa
           GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
           GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
         run: |
@@ -43,31 +50,10 @@ jobs:
           --env GALASA_TOKEN=${{ env.GALASA_TOKEN }} \
           --user galasa:galasa \
           -v ${{ github.workspace }}/galasa:/galasa:rw \
-          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
+          ${{ env.GALASA_CLI_IMAGE }} \
           galasactl runs submit \
           --bootstrap ${{ env.GALASA_SERVICE_BOOTSTRAP_URL }} \
-          --stream ivts \
-          --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
-          --throttle "10" \
-          --poll "10" \
-          --progress "1" \
-          --log -
-
-      - name: Run the 'CoreManagerIVT' on the secure stream
-        env:
-          GALASA_HOME: /galasa
-          GALASA_TOKEN: ${{ secrets.GALASA_TOKEN_SERVICE_MAIN }}
-          GALASA_SERVICE_BOOTSTRAP_URL: ${{ vars.GALASA_SERVICE_BOOTSTRAP_URL }}
-        run: |
-          docker run --rm \
-          --env GALASA_HOME=${{ env.GALASA_HOME }} \
-          --env GALASA_TOKEN=${{ env.GALASA_TOKEN }} \
-          --user galasa:galasa \
-          -v ${{ github.workspace }}/galasa:/galasa:rw \
-          ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:main \
-          galasactl runs submit \
-          --bootstrap ${{ env.GALASA_SERVICE_BOOTSTRAP_URL }} \
-          --stream secure-ivts \
+          --stream ${{ matrix.stream }} \
           --class dev.galasa.ivts/dev.galasa.ivts.core.CoreManagerIVT \
           --throttle "10" \
           --poll "10" \

--- a/.github/workflows/run-core-test.yaml
+++ b/.github/workflows/run-core-test.yaml
@@ -24,10 +24,8 @@ jobs:
         include:
           - test-type: 'service-ivts'
             stream: 'ivts'
-            test-mode: 'service'
           - test-type: 'service-secure-ivts'
             stream: 'secure-ivts'
-            test-mode: 'service'
 
     steps:
       - name: Setup Galasa workspace

--- a/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
+++ b/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
@@ -54,3 +54,20 @@ data:
         # Welcome to your Galasa service
         To Make the most of your Galasa experience, please refer to the [Galasa documentation](https://galasa.dev/)
         ![image](https://raw.githubusercontent.com/galasa-dev/webui/ee5cf521ebb392079b3d672c78ad2da128d8fef9/galasa-ui/public/static/homeGraphic.svg)
+---
+apiVersion: galasa-dev/v1alpha1
+kind: GalasaStream
+metadata:
+    name: secure-ivts
+    description: Galasa IVTs in an authenticated Maven repository
+data:
+    isEnabled: true
+    repository:
+        url: https://development.galasa.dev/main/maven-repo/ivts-auth/
+        secretName: SECURE_IVTS_SECRET
+    obrs:
+        - group-id: dev.galasa
+          artifact-id: dev.galasa.ivts.obr
+          version: 0.48.1
+    testCatalog:
+        url: https://development.galasa.dev/main/maven-repo/ivts-auth/dev/galasa/dev.galasa.ivts.obr/0.48.1/dev.galasa.ivts.obr-0.48.1-testcatalog.json

--- a/releasePipeline/set-version.sh
+++ b/releasePipeline/set-version.sh
@@ -191,6 +191,34 @@ function upgrade_isolated_mvp_zip_version {
     update_property_version "${prod1_properties_file}" "${property_name}" "${value_regex}" "${new_value}"
 }
 
+#bumping version for the secure-ivts GalasaStream resource
+function upgrade_secure_ivts_stream_version {
+    h1 "Bumping up the version in the secure-ivts GalasaStream resource"
+    
+    service_main_resources_file="${WORKSPACE_DIR}/infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml"
+    
+    # Update the version field in the obrs section
+    version_regex="version: [0-9.]+"
+    version_new_value="version: ${galasa_version}"
+    
+    # Update the testCatalog URL
+    testcatalog_regex="url: https:\\/\\/development[.]galasa[.]dev\\/main\\/maven-repo\\/ivts-auth\\/dev\\/galasa\\/dev[.]galasa[.]ivts[.]obr\\/[0-9.]+\\/dev[.]galasa[.]ivts[.]obr-[0-9.]+-testcatalog[.]json"
+    testcatalog_new_value="url: https:\\/\\/development.galasa.dev\\/main\\/maven-repo\\/ivts-auth\\/dev\\/galasa\\/dev.galasa.ivts.obr\\/${galasa_version}\\/dev.galasa.ivts.obr-${galasa_version}-testcatalog.json"
+    
+    mkdir -p ${BASEDIR}/temp
+    temp_file="${BASEDIR}/temp/galasa-service-main-resources.yaml"
+    
+    # Apply both replacements
+    cat ${service_main_resources_file} | sed -E "s/${version_regex}/${version_new_value}/1" | sed -E "s/${testcatalog_regex}/${testcatalog_new_value}/1" > ${temp_file}
+    rc=$?; if [[ "${rc}" != "0" ]]; then error "Failed to bump version in secure-ivts GalasaStream resource."; exit 1; fi
+    
+    cp ${temp_file} ${service_main_resources_file}
+    if ! grep -q -E "${version_new_value}" ${service_main_resources_file}; then error "Failed to replace version field in secure-ivts GalasaStream resource."; exit 1; fi
+    if ! grep -q -E "dev.galasa.ivts.obr\\/${galasa_version}\\/dev.galasa.ivts.obr-${galasa_version}-testcatalog.json" ${service_main_resources_file}; then error "Failed to replace testCatalog URL in secure-ivts GalasaStream resource."; exit 1; fi
+    
+    success "secure-ivts GalasaStream version bumped successfully"
+}
+
 #bumping version for the value of property runtime.version
 function upgrade_galasa_versions {
     runtime_version_prop="runtime.version"
@@ -260,3 +288,4 @@ upgrade_test_stream_simbank_obr_version
 upgrade_isolated_full_zip_version
 upgrade_isolated_mvp_zip_version
 upgrade_galasa_versions
+upgrade_secure_ivts_stream_version


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1572

## Changes
- [x] Added a matrix step to the `run-core-test` workflow that runs the CoreManagerIVT test from the authenticated IVTs maven repo
- [x] Added a new 'secure-ivts' test stream resource definition to the galasa-service-main resources YAML file
- [x] Updated the set-version script to bump the Galasa version listed in the new test stream