### PR TITLE
Update Manual Steps with Scoop Installer

### DIFF
--- a/releasePipeline/44-update-homebrew-and-scoop.md
+++ b/releasePipeline/44-update-homebrew-and-scoop.md
@@ -4,10 +4,19 @@ We are maintaining a homebrew tap for each release.
 
 Now we have a new CLI, we want to publish it's availability for homebrew users.
 
-- Clone the homebrew repo
+- Clone the homebrew-tap repo
 - Run the `./add-version.sh --version xx.xx.xx` script. `xx.xx.xx` is the new version we just released.
 - Check that there is a new formula present
 - Check that the 'latest' formula has been updated to the new version.
 - Check that the examples in the `README.md` changed.
 - Deliver that change to the code stream.
 
+# Update Scoop
+
+We are also maintaining a scoop bucket for each release.
+
+- Clone the scoop-bucket repo
+- Run the `./add-version.sh --version xx.xx.xx` script. `xx.xx.xx` is the new version we just released.
+- Check that there is a new json manifest in the `/bucket` directory for the new version.
+- Check that `bucket/galasactl.json` has been updated to the new version.
+- Deliver that change to the code stream.

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -120,9 +120,9 @@ For any tests which fail, run them again individually:
 1. [42-upload-cli-release.md](./42-upload-cli-release.md) - Follow instructions to upload the CLI binaries to the repository under a new release.
 1. [43-upload-isolated-release.md](./43-upload-isolated-release.md) - Follow instructions to upload the Isolated and MVP zips to the repository under a new release.
 
-### Update Homebrew installed for the CLI
+### Update Homebrew and scoop installed for the CLI
 
-1. [44-update-homebrew.md](./44-update-homebrew.md) - Follow the manual steps in this file to make the new version of the CLI available for the homebrew installer.
+1. [44-update-homebrew-and-scoop.md](./44-update-homebrew-and-scoop.md) - Follow the manual steps in this file to make the new version of the CLI available for the homebrew and scoop installers.
 
 ### Bump to new version for development
 


### PR DESCRIPTION
# Why?

References https://github.com/galasa-dev/projectmanagement/issues/1989.

Updates manual steps to include the instructions for updating the version on scoop for windows users.