### PR TITLE
Uplift golang x/next dependency in github-webhook-receiver

### DIFF
--- a/build-images/github-webhook-receiver/go.mod
+++ b/build-images/github-webhook-receiver/go.mod
@@ -12,6 +12,6 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )


### PR DESCRIPTION
## Why?

LF Insights OSS vulnerabilities report found a Critical in golang.org/x/net v0.25.0. 

## Changes

Uplifting to v0.55.0 as it is unaffected.