### PR TITLE
Add GitHub Actions workflow to automate the pre-release process

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,98 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This workflow automates the Galasa pre-release process.
+#
+# Required Secrets:
+#   ARGOCD_AUTH_TOKEN         - Authentication token for ArgoCD CLI
+#   GALASA_TEAM_GITHUB_TOKEN  - GitHub token with repo and workflow permissions
+#
+name: Pre-Release Process
+
+on:
+  workflow_dispatch:
+
+env:
+  TERM: xterm-256color
+
+jobs:
+  pre-release:
+    name: Run Pre-Release Automation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout automation repository
+        uses: actions/checkout@v4
+
+      - name: Install ArgoCD CLI
+        run: |
+          curl -sSL -o /tmp/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+          sudo install -m 555 /tmp/argocd /usr/local/bin/argocd
+          argocd version --client
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl unzip
+          echo "Tools installed successfully"
+
+      - name: Authenticate GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "GALASA_TEAM_GITHUB_TOKEN secret is not set"
+            exit 1
+          fi
+          gh auth status
+          echo "GitHub CLI authentication successful"
+
+      - name: Clean up existing ArgoCD apps
+        env:
+          ARGOCD_SERVER: argocd.galasa.dev
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          ARGOCD_OPTS: --grpc-web
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          chmod +x 92-delete-argocd-apps.sh
+          ./92-delete-argocd-apps.sh
+
+      - name: Run pre-release script
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          ARGOCD_SERVER: argocd.galasa.dev
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN }}
+          ARGOCD_OPTS: --grpc-web
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          # Verify ArgoCD authentication is configured
+          if [[ -z "$ARGOCD_AUTH_TOKEN" ]]; then
+            echo "ARGOCD_AUTH_TOKEN secret is not set"
+            exit 1
+          fi
+          
+          chmod +x 01-run-pre-release.sh
+          ./01-run-pre-release.sh --prerelease
+
+      - name: Test MVP zip
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          chmod +x test-mvp-zip.sh
+          ./test-mvp-zip.sh --prerelease
+
+      - name: Upload MVP test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mvp-test-results-prerelease
+          path: |
+            ${{ github.workspace }}/releasePipeline/temp/mvp-test-*/
+            !${{ github.workspace }}/releasePipeline/temp/mvp-test-*/galasa-isolated-mvp-*.zip
+            !${{ github.workspace }}/releasePipeline/temp/mvp-test-*/isolated.tar
+            !${{ github.workspace }}/releasePipeline/temp/mvp-test-*/maven/
+          retention-days: 7

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,9 +14,6 @@ name: Pre-Release Process
 on:
   workflow_dispatch:
 
-env:
-  TERM: xterm-256color
-
 jobs:
   pre-release:
     name: Run Pre-Release Automation

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -14,6 +14,11 @@ name: Pre-Release Process
 on:
   workflow_dispatch:
 
+env:
+  # Set TERM to xterm-256color to fix errors in set-version scripts that use tput.
+  # GitHub Actions doesn't set TERM by default, causing tput commands to fail.
+  TERM: xterm-256color
+
 jobs:
   pre-release:
     name: Run Pre-Release Automation

--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -13,6 +13,11 @@
 # 
 #-----------------------------------------------------------------------------------------     
 
+# Set TERM if not already set
+if [ -z "${TERM}" ]; then
+    export TERM="xterm-256color"
+fi
+
 # Where is this script executing from ?
 RELEASE_BASEDIR=$(dirname "$0");pushd $RELEASE_BASEDIR 2>&1 >> /dev/null ;RELEASE_BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 export ORIGINAL_DIR=$(pwd)

--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -13,11 +13,6 @@
 # 
 #-----------------------------------------------------------------------------------------     
 
-# Set TERM if not already set
-if [ -z "${TERM}" ]; then
-    export TERM="xterm-256color"
-fi
-
 # Where is this script executing from ?
 RELEASE_BASEDIR=$(dirname "$0");pushd $RELEASE_BASEDIR 2>&1 >> /dev/null ;RELEASE_BASEDIR=$(pwd);popd 2>&1 >> /dev/null
 export ORIGINAL_DIR=$(pwd)

--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright contributors to the Galasa project
@@ -48,10 +48,153 @@ warn()      { printf "${tan}➜ %s${reset}\n" "$@" ; }
 bold()      { printf "${bold}%s${reset}\n" "$@" ; }
 note()      { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
 
+#-----------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------------------                   
+function wait_for_isolated_build {
+    h2 "Waiting for Isolated build to complete"
+    
+    local start_time="$1"
+    MAX_WAIT_ITERATIONS=50
+    COUNTER=0
+    release_type="prerelease"
+    SLEEP_TIME_SECONDS=120
+    
+    info "Looking for Isolated builds created after: ${start_time}"
+    
+    while [[ $COUNTER -lt $MAX_WAIT_ITERATIONS ]]; do
+        info "Checking for Isolated build workflow... (attempt $((COUNTER+1))/$MAX_WAIT_ITERATIONS)"
+        
+        # Get workflow runs for the prerelease branch created after our start time
+        run_data=$(gh run list --repo galasa-dev/isolated --workflow build.yaml --branch ${release_type} --limit 5 --json databaseId,createdAt,conclusion 2>&1)
+        
+        # Check if the command succeeded
+        if [[ $? -ne 0 ]]; then
+            warn "Failed to query workflow runs: ${run_data}"
+            continue
+        fi
+        
+        # Validate JSON data
+        if ! echo "$run_data" | jq empty 2>/dev/null; then
+            warn "Invalid JSON response from GitHub API"
+            continue
+        fi
+        
+        # Find the first run created after our start time
+        run_id=$(echo "$run_data" | jq -r --arg start_time "$start_time" '.[] | select(.createdAt > $start_time) | .databaseId' 2>/dev/null | head -1)
+        
+        if [[ -n "$run_id" ]]; then
+            info "Found Isolated build workflow run: ${run_id}"
+            
+            # Get the full status of this specific run
+            run_info=$(echo "$run_data" | jq -r --arg run_id "$run_id" '.[] | select(.databaseId == ($run_id | tonumber))')
+            status=$(echo "$run_info" | jq -r '.conclusion')
+            created_at=$(echo "$run_info" | jq -r '.createdAt')
+            
+            info "Workflow created at: ${created_at}"
+            
+            if [[ "$status" == "success" ]]; then
+                success "Isolated build completed successfully."
+                info "View at: https://github.com/galasa-dev/isolated/actions/runs/${run_id}"
+                return 0
+            elif [[ "$status" == "failure" || "$status" == "cancelled" ]]; then
+                error "Isolated build failed or was cancelled."
+                error "Check https://github.com/galasa-dev/isolated/actions/runs/${run_id}"
+                exit 1
+            elif [[ "$status" == "null" || -z "$status" ]]; then
+                info "Isolated build status: in_progress"
+            else
+                info "Isolated build status: ${status}"
+            fi
+        else
+            info "Isolated build workflow not yet started (no runs found after ${start_time})..."
+        fi
+        
+        # Sleep before next check
+        info "Waiting for ${SLEEP_TIME_SECONDS} seconds before checking again..."
+        sleep $SLEEP_TIME_SECONDS || true
+        ((COUNTER++)) || true
+    done
+    
+    error "Timed out waiting for Isolated build to complete"
+    error "Check https://github.com/galasa-dev/isolated/actions for status"
+    exit 1
+}
+
+function wait_for_webui_build {
+    h2 "Waiting for Web UI build to complete"
+    
+    local start_time="$1"
+    MAX_WAIT_ITERATIONS=50
+    COUNTER=0
+    release_type="prerelease"
+    SLEEP_TIME_SECONDS=60
+    
+    info "Looking for Web UI builds created after: ${start_time}"
+    
+    while [[ $COUNTER -lt $MAX_WAIT_ITERATIONS ]]; do
+        info "Checking for Web UI build workflow... (attempt $((COUNTER+1))/$MAX_WAIT_ITERATIONS)"
+        
+        # Get workflow runs for the prerelease branch created after our start time
+        run_data=$(gh run list --repo galasa-dev/webui --workflow build.yaml --branch ${release_type} --limit 5 --json databaseId,createdAt,conclusion 2>&1)
+        
+        # Check if the command succeeded
+        if [[ $? -ne 0 ]]; then
+            warn "Failed to query workflow runs: ${run_data}"
+            continue
+        fi
+        
+        # Validate JSON data
+        if ! echo "$run_data" | jq empty 2>/dev/null; then
+            warn "Invalid JSON response from GitHub API"
+            continue
+        fi
+        
+        # Find the first run created after our start time
+        run_id=$(echo "$run_data" | jq -r --arg start_time "$start_time" '.[] | select(.createdAt > $start_time) | .databaseId' 2>/dev/null | head -1)
+        
+        if [[ -n "$run_id" ]]; then
+            info "Found Web UI build workflow run: ${run_id}"
+            
+            # Get the full status of this specific run
+            run_info=$(echo "$run_data" | jq -r --arg run_id "$run_id" '.[] | select(.databaseId == ($run_id | tonumber))')
+            status=$(echo "$run_info" | jq -r '.conclusion')
+            created_at=$(echo "$run_info" | jq -r '.createdAt')
+            
+            info "Workflow created at: ${created_at}"
+            
+            if [[ "$status" == "success" ]]; then
+                success "Web UI build completed successfully."
+                info "View at: https://github.com/galasa-dev/webui/actions/runs/${run_id}"
+                return 0
+            elif [[ "$status" == "failure" || "$status" == "cancelled" ]]; then
+                error "Web UI build failed or was cancelled."
+                error "Check https://github.com/galasa-dev/webui/actions/runs/${run_id}"
+                exit 1
+            elif [[ "$status" == "null" || -z "$status" ]]; then
+                info "Web UI build status: in_progress"
+            else
+                info "Web UI build status: ${status}"
+            fi
+        else
+            info "Web UI build workflow not yet started (no runs found after ${start_time})..."
+        fi
+        
+        # Sleep before next check
+        info "Waiting for ${SLEEP_TIME_SECONDS} seconds before checking again..."
+        sleep $SLEEP_TIME_SECONDS || true
+        ((COUNTER++)) || true
+    done
+    
+    error "Timed out waiting for Web UI build to complete"
+    error "Check https://github.com/galasa-dev/webui/actions for status"
+    exit 1
+}
+
+#-----------------------------------------------------------------------------------------
 # Main Program
-#-----------------------------------------------------------------------------------------   
+#-----------------------------------------------------------------------------------------
 set -e
 
 h1 "run 02-create-argocd-apps.sh"
@@ -60,14 +203,31 @@ $RELEASE_BASEDIR/02-create-argocd-apps.sh --prerelease
 h1 "run 03-repo-branches-delete.sh"
 $RELEASE_BASEDIR/03-repo-branches-delete.sh --prerelease
 
+# Capture timestamp before creating branches
+# This ensures we can identify workflows triggered by the branch creation
+BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+info "Branch creation time: ${BRANCH_CREATE_TIME}"
+
 h1 "run 04-repo-branches-create.sh"
 $RELEASE_BASEDIR/04-repo-branches-create.sh --prerelease
 
 h1 "run 05-helm-charts.sh"
-$RELEASE_BASEDIR/05-helm-charts.sh --prerelease
+$RELEASE_BASEDIR/05-helm-charts.sh --prerelease --start-time "${BRANCH_CREATE_TIME}"
 
 h1 "run 10-build-galasa-mono-repo.sh"
+
+# Capture the current time before starting the build
+# This ensures we only wait for workflows created after this point
+BUILD_START_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+info "Build start time: ${BUILD_START_TIME}"
+
 $RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --prerelease --wait
 
+h1 "Waiting for downstream builds to complete"
+wait_for_isolated_build "${BUILD_START_TIME}"
+wait_for_webui_build "${BUILD_START_TIME}"
+
 h1 "run 20-check-artifacts-signed.sh"
-$RELEASE_BASEDIR/20-check-artifacts-signed.sh
+$RELEASE_BASEDIR/20-check-artifacts-signed.sh --prerelease
+
+success "Pre-release automation completed successfully!"

--- a/releasePipeline/05-helm-charts.sh
+++ b/releasePipeline/05-helm-charts.sh
@@ -63,6 +63,7 @@ function usage {
 Options are:
 --prerelease : Checks the Galasa helm charts can be released for the pre-release process.
 --release : Checks the Galasa helm charts have been released for the release process.
+--start-time <timestamp> : ISO 8601 timestamp to use for filtering workflow runs (optional, defaults to current time)
 EOF
 }
 
@@ -111,7 +112,7 @@ function clone_helm_repository {
     h1 "Cloning the '${release_type}' branch of the 'helm' repository into the 'temp' directory..."
 
     cd ${WORKSPACE_DIR}/temp
-    git clone --branch ${release_type} git@github.com:galasa-dev/helm.git
+    git clone --branch ${release_type} https://github.com/galasa-dev/helm.git
     
     success "'${release_type}' branch of the 'helm' repository cloned."
 
@@ -149,29 +150,73 @@ function check_helm_charts_released {
 
     h1 "Checking the Helm charts were released..."
 
-    info "First, checking that the GitHub Actions workflow to release them, is no longer active..."
+    info "Waiting for Helm chart release workflow to start and complete..."
 
+    # Use the provided start time or default to current time
+    if [[ -z "${start_time}" ]]; then
+        start_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        info "No start time provided, using current time: ${start_time}"
+    fi
+    
+    info "Looking for workflow runs created after: ${start_time}"
+
+    workflow_found="false"
     workflow_finished="false"
     retries=0
     max=100
-    target_line=""
+    run_id=""
 
     while [[ "${workflow_finished}" == "false" ]]; do
 
-        url=https://api.github.com/repos/galasa-dev/helm/actions/runs?status=in_progress
-        curl $url > temp/workflows_in_progress.txt -s
+        # Get recent workflow runs for the release branch
+        url="https://api.github.com/repos/galasa-dev/helm/actions/workflows/release.yaml/runs?branch=${release_type}&per_page=5"
+        curl -s "$url" > temp/helm_workflow_runs.json
 
-        target_line=$(cat temp/workflows_in_progress.txt | grep "\"total_count\": 0")
+        # Find the most recent run created after our branch creation time
+        if [[ "${workflow_found}" == "false" ]]; then
+            # Look for a workflow run that started after we created the branch
+            run_id=$(cat temp/helm_workflow_runs.json | jq -r --arg start_time "$start_time" '.workflow_runs[] | select(.created_at > $start_time) | .id' | head -1)
+            
+            if [[ -n "$run_id" ]]; then
+                workflow_found="true"
+                info "Found Helm release workflow run: ${run_id}"
+                info "View at: https://github.com/galasa-dev/helm/actions/runs/${run_id}"
+            else
+                info "Waiting for Helm release workflow to start... (attempt $((retries+1))/${max})"
+            fi
+        fi
 
-        if [[ "$target_line" != "" ]]; then
-            success "Target line is found - the workflow is now finished."
-            workflow_finished="true"
-        fi    
-        sleep 5
-        ((retries++))
-        if (( $retries > $max )); then 
-            error "Too many retries."
-            exit 1
+        # If we found the workflow, check its status
+        if [[ "${workflow_found}" == "true" ]]; then
+            status=$(cat temp/helm_workflow_runs.json | jq -r --arg run_id "$run_id" '.workflow_runs[] | select(.id == ($run_id | tonumber)) | .status')
+            conclusion=$(cat temp/helm_workflow_runs.json | jq -r --arg run_id "$run_id" '.workflow_runs[] | select(.id == ($run_id | tonumber)) | .conclusion')
+            
+            if [[ "$status" == "completed" ]]; then
+                if [[ "$conclusion" == "success" ]]; then
+                    success "Helm release workflow completed successfully."
+                    workflow_finished="true"
+                else
+                    error "Helm release workflow failed with conclusion: ${conclusion}"
+                    error "Check https://github.com/galasa-dev/helm/actions/runs/${run_id}"
+                    exit 1
+                fi
+            else
+                info "Helm release workflow status: ${status}"
+            fi
+        fi
+
+        if [[ "${workflow_finished}" == "false" ]]; then
+            sleep 5
+            ((retries++))
+            if (( $retries > $max )); then
+                error "Timed out waiting for Helm release workflow."
+                if [[ -n "$run_id" ]]; then
+                    error "Check https://github.com/galasa-dev/helm/actions/runs/${run_id}"
+                else
+                    error "Check https://github.com/galasa-dev/helm/actions"
+                fi
+                exit 1
+            fi
         fi
     done
 
@@ -235,11 +280,15 @@ function delete_pre_release_helm_charts {
 # Process parameters
 #-----------------------------------------------------------------------------------------
 release_type=""
+start_time=""
 while [ "$1" != "" ]; do
     case $1 in
         --prerelease )          release_type="prerelease"
                                 ;;
         --release )             release_type="release"
+                                ;;
+        --start-time )          shift
+                                start_time="$1"
                                 ;;
         -h | --help )           usage
                                 exit

--- a/releasePipeline/20-check-artifacts-signed.sh
+++ b/releasePipeline/20-check-artifacts-signed.sh
@@ -53,9 +53,9 @@ warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
 bold() { printf "${bold}%s${reset}\n" "$@" ;}
 note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
 
-#-----------------------------------------------------------------------------------------                   
+#-----------------------------------------------------------------------------------------
 # Main logic.
-#-----------------------------------------------------------------------------------------                   
+#-----------------------------------------------------------------------------------------
 
 mkdir -p temp
 
@@ -77,6 +77,43 @@ function ask_user_for_release_type {
         esac
     done
     echo "Chosen type of release process: ${release_type}"
+}
+
+function parse_args {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --release)
+                export release_type="release"
+                shift
+                ;;
+            --prerelease)
+                export release_type="prerelease"
+                shift
+                ;;
+            *)
+                error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+    
+    # If no release type was provided via flags, ask the user
+    if [[ -z "${release_type}" ]]; then
+        ask_user_for_release_type
+    fi
+    
+    info "Release type: ${release_type}"
+}
+
+function usage {
+    h1 "Usage: $0 [--release|--prerelease]"
+    echo ""
+    echo "Options:"
+    echo "  --release      Check artifacts for release build"
+    echo "  --prerelease   Check artifacts for pre-release build"
+    echo ""
+    echo "If no option is provided, you will be prompted to select one."
 }
 
 
@@ -140,7 +177,7 @@ function check_maven_repo_for_jar_asc {
     success "The .pom.asc file for artifact ${artifact_name} was found."
 }
 
-ask_user_for_release_type
+parse_args "$@"
 
 declare -a artifact_list=(
     "dev.galasa.platform"\

--- a/releasePipeline/92-delete-argocd-apps.sh
+++ b/releasePipeline/92-delete-argocd-apps.sh
@@ -6,13 +6,14 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-argocd app delete release-maven-repos --grpc-web
-argocd app delete release-bld --grpc-web
-argocd app delete release-cli --grpc-web
-argocd app delete release-simplatform --grpc-web
-argocd app delete prerelease-maven-repos --grpc-web
-argocd app delete prerelease-bld --grpc-web
-argocd app delete prerelease-cli --grpc-web
-argocd app delete prerelease-simplatform --grpc-web
+# Delete ArgoCD apps, ignoring errors if they don't exist
+argocd app delete release-maven-repos --grpc-web --yes 2>/dev/null || true
+argocd app delete release-bld --grpc-web --yes 2>/dev/null || true
+argocd app delete release-cli --grpc-web --yes 2>/dev/null || true
+argocd app delete release-simplatform --grpc-web --yes 2>/dev/null || true
+argocd app delete prerelease-maven-repos --grpc-web --yes 2>/dev/null || true
+argocd app delete prerelease-bld --grpc-web --yes 2>/dev/null || true
+argocd app delete prerelease-cli --grpc-web --yes 2>/dev/null || true
+argocd app delete prerelease-simplatform --grpc-web --yes 2>/dev/null || true
 
-echo "Complete"
+echo "ArgoCD apps cleanup complete"

--- a/releasePipeline/92-delete-argocd-apps.sh
+++ b/releasePipeline/92-delete-argocd-apps.sh
@@ -7,13 +7,13 @@
 #
 
 # Delete ArgoCD apps, ignoring errors if they don't exist
-argocd app delete release-maven-repos --grpc-web --yes 2>/dev/null || true
-argocd app delete release-bld --grpc-web --yes 2>/dev/null || true
-argocd app delete release-cli --grpc-web --yes 2>/dev/null || true
-argocd app delete release-simplatform --grpc-web --yes 2>/dev/null || true
-argocd app delete prerelease-maven-repos --grpc-web --yes 2>/dev/null || true
-argocd app delete prerelease-bld --grpc-web --yes 2>/dev/null || true
-argocd app delete prerelease-cli --grpc-web --yes 2>/dev/null || true
-argocd app delete prerelease-simplatform --grpc-web --yes 2>/dev/null || true
+argocd app delete release-maven-repos --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete release-bld --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete release-cli --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete release-simplatform --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete prerelease-maven-repos --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete prerelease-bld --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete prerelease-cli --grpc-web --yes --wait 2>/dev/null || true
+argocd app delete prerelease-simplatform --grpc-web --yes --wait 2>/dev/null || true
 
 echo "ArgoCD apps cleanup complete"

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -4,7 +4,17 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 
 **Do not check in any changes you make to files during this work item unless you are correcting a mistake - back out everything at the end**
 
-## Set up
+## Pre-release steps - Automated
+
+1. Run the [Pre-release GitHub Actions workflow](https://github.com/galasa-dev/automation/actions/workflows/pre-release.yaml). If the process fails at any stage, you can continue by re-running the script that failed from the manual steps and finish using the [manual steps below](#pre-release-steps---manual).
+2. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) to check for any vulnerabilities before moving onto the release process.
+3. Make sure that no Releases or Tags for the Helm charts were left behind during the GitHub Actions workflow run.
+    1. Delete all Releases that were created: [Releases](https://github.com/galasa-dev/helm/releases) - Next to a Release, click the Delete icon and 'Delete this release'.
+    2. Delete all Tags that were created: [Tags](https://github.com/galasa-dev/helm/tags) - Next to a Tag, click the three dots, then 'Delete Tag' then 'Delete this Tag'.
+
+## Pre-release steps - Manual
+
+### Set up
 
 1. Clone the 'automation' repository, main branch. All the yaml and scripts you will be using can be found in the releasePipeline folder.
 2. Ensure the ArgoCD CLI is installed. The argocd cli can be downloaded [here]( https://argo-cd.readthedocs.io/en/stable/cli_installation/).
@@ -14,19 +24,10 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 6. Ensure the Tekton CLI is installed. You can download it [here](https://tekton.dev/docs/cli/).
 7. Authenticate to the cicsk8s cluster using `cicsk8s sso`
 
-## Pre-release steps - Automated
+### Steps
 
 1. Ensure you have completed the [set up](#set-up) before continuing.
-2. Run [01-run-pre-release.sh](./01-run-pre-release.sh). If the process fails at any stage, you can continue by re-running the script that failed from the manual steps and finish using the [manual steps below](#pre-release-steps---manual).
-3. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) to check for any vulnerabilities before moving onto the release process.
-4. Delete all Releases and Tags for the Helm charts that were just created during the [01-run-pre-release.sh](./01-run-pre-release.sh) script.
-    1. Delete all Releases that were created: [Releases](https://github.com/galasa-dev/helm/releases) - Next to a Release, click the Delete icon and 'Delete this release'.
-    2. Delete all Tags that were created: [Tags](https://github.com/galasa-dev/helm/tags) - Next to a Tag, click the three dots, then 'Delete Tag' then 'Delete this Tag'.
-
-## Pre-release steps - Manual
-
-1. Ensure you have completed the [set up](#set-up) before continuing.
-2. Run [02-create-argocd-apps.sh](./02-create-argocd-apps.sh). When prompted, choose the '`pre-release`' option.
+2.  Run [02-create-argocd-apps.sh](./02-create-argocd-apps.sh). When prompted, choose the '`pre-release`' option.
 3. Run [03-repo-branches-delete.sh](./03-repo-branches-delete.sh). When prompted, choose the '`pre-release`' option.
 This script kicks off a pipeline to delete all branches called `prerelease` in all the github repositories, so we know they are clean.
 4. Run [04-repo-branches-create.sh](./04-repo-branches-create.sh).  When prompted, choose the '`pre-release`' option.  This script creates
@@ -40,7 +41,7 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
     - Watch the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
 9. The build of the Web UI will also be triggered automatically as part of the build chain, so monitor this build and make sure it finishes successfully.
    - Watch the [Web UI Main build workflow](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
-10. Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
+10.  Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
 ## Test and scan the MVP

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -8,9 +8,6 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 
 1. Run the [Pre-release GitHub Actions workflow](https://github.com/galasa-dev/automation/actions/workflows/pre-release.yaml). If the process fails at any stage, you can continue by re-running the script that failed from the manual steps and finish using the [manual steps below](#pre-release-steps---manual).
 2. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) to check for any vulnerabilities before moving onto the release process.
-3. Make sure that no Releases or Tags for the Helm charts were left behind during the GitHub Actions workflow run.
-    1. Delete all Releases that were created: [Releases](https://github.com/galasa-dev/helm/releases) - Next to a Release, click the Delete icon and 'Delete this release'.
-    2. Delete all Tags that were created: [Tags](https://github.com/galasa-dev/helm/tags) - Next to a Tag, click the three dots, then 'Delete Tag' then 'Delete this Tag'.
 
 ## Pre-release steps - Manual
 
@@ -27,7 +24,7 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 ### Steps
 
 1. Ensure you have completed the [set up](#set-up) before continuing.
-2.  Run [02-create-argocd-apps.sh](./02-create-argocd-apps.sh). When prompted, choose the '`pre-release`' option.
+2. Run [02-create-argocd-apps.sh](./02-create-argocd-apps.sh). When prompted, choose the '`pre-release`' option.
 3. Run [03-repo-branches-delete.sh](./03-repo-branches-delete.sh). When prompted, choose the '`pre-release`' option.
 This script kicks off a pipeline to delete all branches called `prerelease` in all the github repositories, so we know they are clean.
 4. Run [04-repo-branches-create.sh](./04-repo-branches-create.sh).  When prompted, choose the '`pre-release`' option.  This script creates
@@ -41,7 +38,7 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
     - Watch the [Isolated Main build workflow](https://github.com/galasa-dev/isolated/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
 9. The build of the Web UI will also be triggered automatically as part of the build chain, so monitor this build and make sure it finishes successfully.
    - Watch the [Web UI Main build workflow](https://github.com/galasa-dev/webui/actions/workflows/build.yaml) for the `prerelease` ref back in GitHub
-10.  Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
+10. Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
 ## Test and scan the MVP


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2593

## Changes
- [x] Added a GH Actions workflow to run through the pre-release process that first deletes any existing prerelease ArgoCD apps, then runs the `01-run-pre-release.sh` script, and then tests the pre-release MVP zip by running the `test-mvp-zip.sh` script
- [x] Updated the `01-run-pre-release.sh` script to wait for the isolated and webui builds to finish before proceeding (this was previously manual)
- [x] Added `--prerelease` and `--release` flags to the `20-check-artifacts-signed.sh` script to allow scripts to proceed without user input