### PR TITLE
Update pre-release and release docs

### DIFF
--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Required secrets:
-#   - IBM_CLOUD_API_KEY: API key for IBM Cloud Container Registry authentication
+#   - GALASA_TEAM_ICR_API_KEY: API key for IBM Cloud Container Registry authentication
 #   - GALASA_TEAM_GITHUB_TOKEN: Token for triggering workflows in other GitHub repositories
 #   - WRITE_GITHUB_PACKAGES_TOKEN: Token for pushing images to GitHub Container Registry
 # Required vars:
@@ -126,7 +126,7 @@ jobs:
     name: Deploy Docker Images to IBM Cloud
     runs-on: ubuntu-latest
     needs: [get-galasa-version, publish-to-maven-central]
-    if: ${{ !inputs.skip_docker_deploy }}
+    if: ${{ always() && !inputs.skip_docker_deploy && (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') }}
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -201,6 +201,7 @@ jobs:
     name: Create Version Tags
     runs-on: ubuntu-latest
     needs: [get-galasa-version, deploy-docker-images]
+    if: ${{ always() && (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') }}
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}

--- a/releasePipeline/95-move-to-new-version.md
+++ b/releasePipeline/95-move-to-new-version.md
@@ -42,13 +42,7 @@ These are manual steps to bump the version of Galasa to the next version.
     
     b. Push the changes to your branch, open a PR, wait for the PR build to pass, then merge in the PR, and wait for the Main build to pass and finish.
 
-7. Upgrade the [internal integrated tests](https://github.ibm.com/galasa/internal-integratedtests) (not a released component)
-
-    a. Invoke the `set-version --version {new version}` script.
-    
-    b. Push the changes to your branch, open a PR, then merge in the PR, and wait for the Main build to pass and finish.
-
-8. Upgrade [Isolated](https://github.com/galasa-dev/isolated)
+7. Upgrade [Isolated](https://github.com/galasa-dev/isolated)
 
     a. Invoke the `set-version --version {new version}` script.
 

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -7,7 +7,7 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 ## Pre-release steps - Automated
 
 1. Run the [Pre-release GitHub Actions workflow](https://github.com/galasa-dev/automation/actions/workflows/pre-release.yaml). If the process fails at any stage, you can continue by re-running the script that failed from the manual steps and finish using the [manual steps below](#pre-release-steps---manual).
-2. Run a MEND scan for the [MVP zip](https://development.galasa.dev/prerelease/maven-repo/mvp/dev/galasa/galasa-isolated-mvp) by following the instructions in the internal [Developer docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) to check for any vulnerabilities before moving onto the release process.
+2. When the Isolated pre-release build finishes, a Tekton pipeline to copy the MVP to an internal repo should start. Watch that pipeline and review the Mend scan results in the PR that gets opened. Then merge that PR.
 
 ## Pre-release steps - Manual
 

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -39,6 +39,8 @@ This workflow will automatically:
 5. Check artifacts are signed
 6. Test the MVP zip
 7. Run GitHub Actions regression tests in parallel (Isolated, Simbank IVTs, Core IVTs)
+8. Trigger the internal Tekton regression tests after the Isolated build finishes
+9. Trigger the Tekton pipeline to copy the MVP to an internal repo and open a PR for Mend scanning.
 
 Monitor the workflow run at: https://github.com/galasa-dev/automation/actions/workflows/release.yaml
 
@@ -48,20 +50,11 @@ After the automated workflow completes:
 
 #### MEND scan
 
-1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp).
+1. When the Isolated release build finishes, a Tekton pipeline to copy the MVP to an internal repo should start. Watch that pipeline and review the Mend scan results in the PR that gets opened. Then merge that PR.
 
 #### Tekton regression tests
 
-Each of these scripts starts a Tekton pipeline on our internal cluster. This is because these tests require mainframe resource which we don't currently have available externally. These test suites run tests either locally on the Tekton runner, or submit tests to run from Tekton to prod1.
-
-The script will give you the pipeline run name. You will have to monitor the pipeline run in Tekton and ensure it finishes successfully and all tests pass.
-
-**These three steps should be done one after the other.**
-
-<!-- Temporarily removing this step as these tests require a DSE CICS Region which is currently down, so these will always fail -->
-<!-- 1. Run [26-run-cicsts-isolated-tests.sh](./26-run-cicsts-isolated-tests.sh). This tests that the CICS, CEMT, CEDA and SDV Managers work offline using just the Isolated zip. -->
-1. Run [27-run-prod1-ivts.sh](./27-run-prod1-ivts.sh). This tests that the CICS, CEMT, CEDA, SDV and z/OS Managers work online.
-2. Run [28-run-prod1-integration-tests.sh](./28-run-prod1-integration-tests.sh).
+When the Isolated release build finishes, a Tekton pipeline to run the internal regression tests should start. 
 
 Some tests may fail on the first run due to the lack of system resource availability. Rerunning the test should hopefully result in a pass. Make sure that external systems the tests connect to are active and healthy (for example, @hobbit1983's CICS Region).
 
@@ -92,15 +85,21 @@ This workflow will automatically:
 6. Create version tags across all repositories
 7. Upload CLI and Isolated/MVP releases to GitHub
 8. Trigger Homebrew and Scoop update workflows (creates PRs)
-9. Bump development version
+9. Bump development version (creates PRs)
 10. Clean up release resources
 
 
 **Manual actions required**:
 1. Approve Maven Central publication in Portal UI - see [31-publish-to-maven-central.md](./31-publish-to-maven-central.md)
-2. Review and merge Homebrew/Scoop PRs:
+2. Review and merge PRs:
    - [Homebrew tap PR](https://github.com/galasa-dev/homebrew-tap/pulls)
    - [Scoop bucket PR](https://github.com/galasa-dev/scoop-bucket/pulls)
+   - [Galasa PR](https://github.com/galasa-dev/galasa/pulls)
+   - [Helm PR](https://github.com/galasa-dev/helm/pulls)
+   - [Simplatform PR](https://github.com/galasa-dev/simplatform/pulls)
+   - [Web UI PR](https://github.com/galasa-dev/webui/pulls)
+   - [Integratedtests PR](https://github.com/galasa-dev/integratedtests/pulls)
+   - [Isolated PR](https://github.com/galasa-dev/isolated/pulls)
 
 ---
 
@@ -152,6 +151,11 @@ If you need to run steps individually or the automated workflows fail, follow th
 #### Tekton regression tests
 
 **These steps should be done one after the other:**
+
+<!-- Temporarily removing this step as these tests require a DSE CICS Region which is currently down, so these will always fail -->
+<!-- 1. Run [26-run-cicsts-isolated-tests.sh](./26-run-cicsts-isolated-tests.sh). This tests that the CICS, CEMT, CEDA and SDV Managers work offline using just the Isolated zip. -->
+1. Run [27-run-prod1-ivts.sh](./27-run-prod1-ivts.sh). This tests that the CICS, CEMT, CEDA, SDV and z/OS Managers work online.
+2. Run [28-run-prod1-integration-tests.sh](./28-run-prod1-integration-tests.sh).
 
 **All tests must pass before moving on.**
 


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2593

## Changes
- [x] Updated the pre-release and release process instructions based on recent changes to automate the processes
- [x] Also fixed a small issue where if the `deploy-docker-images` job is skipped (via workflow parameters), the jobs that follow would also be skipped - this should not happen anymore