### PR TITLE
Release process publishes Galasa docker images to new galasa namespace

### DIFF
--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 # Required secrets:
-#   - GALASA_TEAM_ICR_API_KEY: API key for IBM Cloud Container Registry authentication
+#   - GALASA_TEAM_ICR_API_KEY: API key for IBM Cloud Container Registry authentication #pragma: allowlist secret
 #   - GALASA_TEAM_GITHUB_TOKEN: Token for triggering workflows in other GitHub repositories
 #   - WRITE_GITHUB_PACKAGES_TOKEN: Token for pushing images to GitHub Container Registry
 # Required vars:
@@ -151,11 +151,17 @@ jobs:
           docker pull ghcr.io/${{ env.NAMESPACE }}/webui:release
 
           docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
+            icr.io/galasa/galasa-ui:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
             icr.io/galasadev/galasa-ui:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
+            icr.io/galasa/galasa-ui:latest
           docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
             icr.io/galasadev/galasa-ui:latest
 
+          docker push icr.io/galasa/galasa-ui:${{ env.GALASA_VERSION }}
           docker push icr.io/galasadev/galasa-ui:${{ env.GALASA_VERSION }}
+          docker push icr.io/galasa/galasa-ui:latest
           docker push icr.io/galasadev/galasa-ui:latest
 
       - name: Deploy Boot Embedded AMD64 image
@@ -164,11 +170,17 @@ jobs:
           docker pull --platform linux/amd64 ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release
 
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
+            icr.io/galasa/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasadev/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
+            icr.io/galasa/galasa-boot-embedded-amd64:latest
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
+          docker push icr.io/galasa/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasadev/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
+          docker push icr.io/galasa/galasa-boot-embedded-amd64:latest
           docker push icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
       - name: Deploy Boot Embedded ARM64 image
@@ -177,11 +189,17 @@ jobs:
           docker pull --platform linux/arm64 ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release
 
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
+            icr.io/galasa/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasadev/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
+            icr.io/galasa/galasa-boot-embedded-arm64:latest
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
+          docker push icr.io/galasa/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasadev/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
+          docker push icr.io/galasa/galasa-boot-embedded-arm64:latest
           docker push icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
       - name: Deploy CLI AMD64 image
@@ -190,11 +208,17 @@ jobs:
           docker pull ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release
 
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
+            icr.io/galasa/galasa-cli-amd64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
             icr.io/galasadev/galasa-cli-amd64:${{ env.GALASA_VERSION }}
+          docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
+            icr.io/galasa/galasa-cli-amd64:latest
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
             icr.io/galasadev/galasa-cli-amd64:latest
 
+          docker push icr.io/galasa/galasa-cli-amd64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasadev/galasa-cli-amd64:${{ env.GALASA_VERSION }}
+          docker push icr.io/galasa/galasa-cli-amd64:latest
           docker push icr.io/galasadev/galasa-cli-amd64:latest
 
   create-version-tags:

--- a/releasePipeline/34-deploy-docker-galasa.sh
+++ b/releasePipeline/34-deploy-docker-galasa.sh
@@ -103,8 +103,12 @@ run_command docker pull ghcr.io/galasa-dev/webui:$FROM
 
 
 run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
+           icr.io/galasa/galasa-ui:$TO
+run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
            icr.io/galasadev/galasa-ui:$TO
 
+run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
+           icr.io/galasa/galasa-ui:latest
 run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
            icr.io/galasadev/galasa-ui:latest
 
@@ -113,8 +117,12 @@ run_command docker tag ghcr.io/galasa-dev/webui:$FROM \
 run_command docker pull --platform linux/amd64 ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
 
 run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasa/galasa-boot-embedded-amd64:$TO
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
            icr.io/galasadev/galasa-boot-embedded-amd64:$TO
 
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasa/galasa-boot-embedded-amd64:latest
 run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
            icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
@@ -122,29 +130,45 @@ run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
 run_command docker pull --platform linux/arm64 ghcr.io/galasa-dev/galasa-boot-embedded:$FROM
 
 run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasa/galasa-boot-embedded-arm64:$TO
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
            icr.io/galasadev/galasa-boot-embedded-arm64:$TO
 
+run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
+           icr.io/galasa/galasa-boot-embedded-arm64:latest
 run_command docker tag ghcr.io/galasa-dev/galasa-boot-embedded:$FROM \
            icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
 
+run_command docker push icr.io/galasa/galasa-boot-embedded-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:$TO
+run_command docker push icr.io/galasa/galasa-boot-embedded-arm64:$TO
 run_command docker push icr.io/galasadev/galasa-boot-embedded-arm64:$TO
+run_command docker push icr.io/galasa/galasa-ui:$TO
 run_command docker push icr.io/galasadev/galasa-ui:$TO
 
 
 
+run_command docker push icr.io/galasa/galasa-boot-embedded-amd64:latest
 run_command docker push icr.io/galasadev/galasa-boot-embedded-amd64:latest
+run_command docker push icr.io/galasa/galasa-boot-embedded-arm64:latest
 run_command docker push icr.io/galasadev/galasa-boot-embedded-arm64:latest
+run_command docker push icr.io/galasa/galasa-ui:latest
 run_command docker push icr.io/galasadev/galasa-ui:latest
 
 # And now for the CLI images...
 run_command docker pull ghcr.io/galasa-dev/galasactl-x86_64:$FROM
 run_command docker tag ghcr.io/galasa-dev/galasactl-x86_64:$FROM \
+           icr.io/galasa/galasa-cli-amd64:$TO
+run_command docker tag ghcr.io/galasa-dev/galasactl-x86_64:$FROM \
            icr.io/galasadev/galasa-cli-amd64:$TO
 run_command docker tag ghcr.io/galasa-dev/galasactl-x86_64:$FROM \
+           icr.io/galasa/galasa-cli-amd64:latest
+run_command docker tag ghcr.io/galasa-dev/galasactl-x86_64:$FROM \
            icr.io/galasadev/galasa-cli-amd64:latest
+run_command docker push icr.io/galasa/galasa-cli-amd64:$TO
 run_command docker push icr.io/galasadev/galasa-cli-amd64:$TO
+run_command docker push icr.io/galasa/galasa-cli-amd64:latest
 run_command docker push icr.io/galasadev/galasa-cli-amd64:latest
 
 success "Completed. Updated the IBM container registry images from verison $FROM to version $TO"


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2490

## Changes

- [x] Updates the release-deployment.yaml workflow and 34-deploy-docker-galasa.sh (old but may be needed for manual release process if there are any issues with automated) to publish the Galasa container images to both the new `icr.io/galasa` namespace and the old `galasadev` namespace. We can stop publishing to `galasadev` in a future release after we are confident users have switched any of their own automation to the new namespace.