### PR TITLE
Iss2621 - Fixes to automated release process 

### DIFF
--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -602,12 +602,7 @@ jobs:
              - Wait for each Main build to complete after merging
              - When Isolated Main build is triggered after Galasa CLI module build, cancel it (you'll rebuild it later)
           
-          2. **Update internal integrated tests** (github.ibm.com/galasa/internal-integratedtests):
-             - Create branch `${{ inputs.branch_name }}`
-             - Run `./set-version.sh --version ${{ inputs.new_version }}`
-             - Create PR, merge, and wait for Main build
-          
-          3. **Update internal test CPS properties** using galasactl:
+          2. **Update internal test CPS properties** using galasactl:
              ```bash
              galasactl properties set \
                --namespace framework \
@@ -622,9 +617,9 @@ jobs:
                --bootstrap <bootstrap-url>
              ```
           
-          4. **Verify CPS properties** were applied correctly in the cluster
+          3. **Verify CPS properties** were applied correctly in the cluster
           
-          5. **Monitor ArgoCD** to ensure the changes are synced properly
+          4. **Monitor ArgoCD** to ensure the changes are synced properly
           
           ### Notes
           - CPS properties are automatically applied by ArgoCD when changes are pushed to the automation repository

--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -270,7 +270,7 @@ jobs:
           
           gh pr create \
             --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }} \
+            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
             --base main \
             --head ${{ inputs.branch_name }}
 

--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -332,6 +332,10 @@ jobs:
     name: Upload GitHub Releases
     runs-on: ubuntu-latest
     needs: [get-galasa-version, create-version-tags]
+    if: |
+      always() && 
+      (needs.get-galasa-version.result) == 'success' &&
+      (needs.create-version-tags.result) == 'success'
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -416,6 +420,10 @@ jobs:
     name: Update Package Managers
     runs-on: ubuntu-latest
     needs: [get-galasa-version, upload-releases]
+    if: |
+      always() && 
+      (needs.get-galasa-version.result) == 'success' &&
+      (needs.upload-releases.result) == 'success'
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -498,6 +506,10 @@ jobs:
     name: Bump Development Version
     runs-on: ubuntu-latest
     needs: [get-galasa-version, update-package-managers]
+    if: |
+      always() && 
+      (needs.get-galasa-version.result) == 'success' &&
+      (needs.update-package-managers.result) == 'success'
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -533,6 +545,10 @@ jobs:
     name: Cleanup Release Resources
     runs-on: ubuntu-latest
     needs: [get-galasa-version, bump-development-version]
+    if: |
+      always() && 
+      (needs.get-galasa-version.result) == 'success' &&
+      (needs.bump-development-version.result) == 'success'
 
     steps:
       - name: Trigger Release Cleanup workflow

--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: false
+      new_galasa_version:
+        description: 'New development version to pass to Bump Development Version workflow (e.g., 1.0.2)'
+        required: true
+        type: string
 
 env:
   NAMESPACE: galasa-dev
@@ -508,7 +512,9 @@ jobs:
 
           gh workflow run bump-development-version.yaml \
             --repo ${{ env.NAMESPACE }}/automation \
-            --ref main
+            --ref main \
+            --field released_version=${{ env.GALASA_VERSION }} \
+            --field new_version=${{ inputs.new_galasa_version }}
 
           sleep 5
 

--- a/releasePipeline/01-run-release.sh
+++ b/releasePipeline/01-run-release.sh
@@ -151,11 +151,16 @@ $RELEASE_BASEDIR/02-create-argocd-apps.sh --release
 h1 "Step 2: Delete old release branches"
 $RELEASE_BASEDIR/03-repo-branches-delete.sh --release
 
+# Capture timestamp before creating branches
+# This ensures we can identify workflows triggered by the branch creation
+BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+info "Branch creation time: ${BRANCH_CREATE_TIME}"
+
 h1 "Step 3: Create new release branches"
 $RELEASE_BASEDIR/04-repo-branches-create.sh --release
 
 h1 "Step 4: Check Helm charts released"
-$RELEASE_BASEDIR/05-helm-charts.sh --release
+$RELEASE_BASEDIR/05-helm-charts.sh --release --start-time "${BRANCH_CREATE_TIME}"
 
 h1 "Step 5: Build Galasa mono repo"
 $RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --release --wait

--- a/releasePipeline/argocd-synced/pipelines/full-regression.yaml
+++ b/releasePipeline/argocd-synced/pipelines/full-regression.yaml
@@ -27,11 +27,11 @@ spec:
 #
 #
 #
-# This just runs DockerLocalJava17Ubuntu now...
+# This pipeline runs DockerLocalJava17Ubuntu and JMeterManagerIVT
 # 
 # 
 # 
-  - name: regression-run
+  - name: runs-prepare-docker
     taskRef: 
       name: galasactl
     params:
@@ -42,18 +42,70 @@ spec:
     - name: command
       value: 
         - runs
-        - submit
-        - --stream
-        - inttests
-        - --package
-        - local
-        - --package
-        - kubernetes
-        - --package
-        - compilation
-        - --trace
+        - prepare
         - --bootstrap
         - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+        - --portfolio
+        - /galasa/tests.yaml
+        - --stream
+        - inttests
+        - --test
+        - local.DockerLocalJava17Ubuntu
+        - --log # Otherwise there is no output
+        - "-"
+# 
+# 
+# 
+  - name: runs-prepare-jmeter
+    taskRef: 
+      name: galasactl
+    runAfter:
+    - runs-prepare-docker
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
+    - name: command
+      value: 
+        - runs
+        - prepare
+        - --bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+        - --portfolio
+        - /galasa/tests.yaml
+        - --append
+        - --stream
+        - ivts
+        - --test
+        - jmeter.JMeterManagerIVT
+        # Override the default engine property in CPS for this test.
+        - --override
+        - docker.default.engines=PRIMARY
+        - --log # Otherwise there is no output
+        - "-"
+# 
+# 
+# 
+
+  - name: runs-submit
+    taskRef: 
+      name: galasactl
+    runAfter:
+    - runs-prepare-jmeter
+    params:
+    - name: context
+      value: $(context.pipelineRun.name)
+    - name: galasaHome
+      value: /workspace/git/$(context.pipelineRun.name)
+    - name: command
+      value: 
+        - runs
+        - submit
+        - --bootstrap
+        - https://prod1-galasa-dev.cicsk8s.hursley.ibm.com/api/bootstrap
+        - --portfolio
+        - /galasa/tests.yaml
         - --throttle
         - '10'
         - --poll


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2621

## Changes 

- [x] Release script was missing the timestamp of the branch create script, so subsequent searches for a Helm release workflow that starts after that time, were unable to find anything (see [here](https://github.com/galasa-dev/automation/actions/runs/30038639325/job/89312829670)). Branch create time is now passed to the Helm release script.
- [x] full-regression Pipeline was missing the new JMeterManagerIVT so it wasn't being run in the release testing. It has now been added.
- [x] Removed instructions for bumping the development version in internal-integratedtests repository as this is no longer required. There are no explicit versions in this repo anymore so the set-version.sh script does not need to run and no changes required to bump development versions.
- [x] Added missing quote `"` to bump development version workflow to fix unexpected EOF failure (see [here](https://github.com/galasa-dev/automation/actions/runs/30090914900/job/89477117848)).
- [x] Added missing inputs to the `gh workflow run` call to bump development version when it is run from the release-deploy workflow. It was missing inputs with no default so would have no way of getting the released/new version.
- [x] Add `always() && (needs...result) == 'success'` to subsequent workflow jobs in release-deploy as they were being skipped even if prior optional jobs were skipped (see [here](https://github.com/galasa-dev/automation/actions/runs/30089491573)).