### PR TITLE
Fix orchestration in release deployment workflow, set automatic maven central publishing, add missing env var

### DIFF
--- a/.github/workflows/release-central-publisher-portal.yaml
+++ b/.github/workflows/release-central-publisher-portal.yaml
@@ -88,4 +88,4 @@ jobs:
             --verbose \
             --header 'Authorization: Bearer ${{ env.PAT }}' \
             --form bundle=@dev-galasa-bundle-${{ env.RELEASE_VERSION }}.zip \
-            https://central.sonatype.com/api/v1/publisher/upload?publishType=USER_MANAGED
+            https://central.sonatype.com/api/v1/publisher/upload?publishType=AUTOMATIC

--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -105,20 +105,6 @@ jobs:
             --sleep 60 \
             --max-iterations 20
 
-      - name: Manual approval required
-        run: |
-          echo "::notice::⏸️ MANUAL APPROVAL REQUIRED"
-          echo "::notice::1. Log into Maven Central Publisher Portal: https://central.sonatype.com/"
-          echo "::notice::2. Navigate to 'View Deployments'"
-          echo "::notice::3. Find bundle: dev-galasa-bundle-${{ env.GALASA_VERSION }}.zip"
-          echo "::notice::4. Validate all checks passed"
-          echo "::notice::5. Click 'Publish' to release to Maven Central"
-          echo "::notice::6. After publishing, this workflow will continue automatically"
-          echo ""
-          echo "Waiting for manual approval in Maven Central Portal..."
-          echo "This step will pause for 10 minutes to allow time for manual approval."
-          echo "The workflow will then poll Maven Central for artifact availability."
-
       - name: Poll Maven Central for artifact availability
         run: |
           ./releasePipeline/32-wait-maven.sh \
@@ -145,9 +131,6 @@ jobs:
         run: |
           echo "Logging into IBM Cloud Container Registry..."
           echo "$IBM_CLOUD_API_KEY" | docker login -u iamapikey --password-stdin icr.io
-
-          # Set region to global
-          ibmcloud cr region-set global
 
       - name: Deploy Web UI image
         run: |
@@ -229,7 +212,10 @@ jobs:
     name: Create Version Tags
     runs-on: ubuntu-latest
     needs: [get-galasa-version, deploy-docker-images]
-    if: ${{ always() && (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') }}
+    if: |
+      always() &&
+      (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') &&
+      (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped')
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -331,11 +317,13 @@ jobs:
   upload-releases:
     name: Upload GitHub Releases
     runs-on: ubuntu-latest
-    needs: [get-galasa-version, create-version-tags]
+    needs: [get-galasa-version, publish-to-maven-central, deploy-docker-images, create-version-tags]
     if: |
-      always() && 
-      (needs.get-galasa-version.result) == 'success' &&
-      (needs.create-version-tags.result) == 'success'
+      always() &&
+      (needs.get-galasa-version.result == 'success') &&
+      (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') &&
+      (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') &&
+      (needs.create-version-tags.result == 'success')
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -419,11 +407,13 @@ jobs:
   update-package-managers:
     name: Update Package Managers
     runs-on: ubuntu-latest
-    needs: [get-galasa-version, upload-releases]
+    needs: [get-galasa-version, publish-to-maven-central, deploy-docker-images, upload-releases]
     if: |
-      always() && 
-      (needs.get-galasa-version.result) == 'success' &&
-      (needs.upload-releases.result) == 'success'
+      always() &&
+      (needs.get-galasa-version.result == 'success') &&
+      (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') &&
+      (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') &&
+      (needs.upload-releases.result == 'success')
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -505,11 +495,13 @@ jobs:
   bump-development-version:
     name: Bump Development Version
     runs-on: ubuntu-latest
-    needs: [get-galasa-version, update-package-managers]
+    needs: [get-galasa-version, publish-to-maven-central, deploy-docker-images, update-package-managers]
     if: |
-      always() && 
-      (needs.get-galasa-version.result) == 'success' &&
-      (needs.update-package-managers.result) == 'success'
+      always() &&
+      (needs.get-galasa-version.result == 'success') &&
+      (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') &&
+      (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') &&
+      (needs.update-package-managers.result == 'success')
 
     env:
       GALASA_VERSION: ${{ needs.get-galasa-version.outputs.galasa-version }}
@@ -544,11 +536,13 @@ jobs:
   cleanup:
     name: Cleanup Release Resources
     runs-on: ubuntu-latest
-    needs: [get-galasa-version, bump-development-version]
+    needs: [get-galasa-version, publish-to-maven-central, deploy-docker-images, bump-development-version]
     if: |
-      always() && 
-      (needs.get-galasa-version.result) == 'success' &&
-      (needs.bump-development-version.result) == 'success'
+      always() &&
+      (needs.get-galasa-version.result == 'success') &&
+      (needs.publish-to-maven-central.result == 'success' || needs.publish-to-maven-central.result == 'skipped') &&
+      (needs.deploy-docker-images.result == 'success' || needs.deploy-docker-images.result == 'skipped') &&
+      (needs.bump-development-version.result == 'success')
 
     steps:
       - name: Trigger Release Cleanup workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,11 @@ name: Release Process
 on:
   workflow_dispatch:
 
+env:
+  # Set TERM to xterm-256color to fix errors in set-version scripts that use tput.
+  # GitHub Actions doesn't set TERM by default, causing tput commands to fail.
+  TERM: xterm-256color
+
 jobs:
   release:
     name: Run Release Automation

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -79,19 +79,17 @@ gh workflow run release-deployment.yaml --repo galasa-dev/automation --ref main
 This workflow will automatically:
 1. Detect the Galasa version from `galasa/build.properties`
 2. Publish artifacts to Maven Central Publisher Portal
-3. **PAUSE for manual approval** - You must log into the Portal and click "Publish"
-4. Poll Maven Central for artifact availability
-5. Deploy Docker images to IBM Cloud Container Registry
-6. Create version tags across all repositories
-7. Upload CLI and Isolated/MVP releases to GitHub
-8. Trigger Homebrew and Scoop update workflows (creates PRs)
-9. Bump development version (creates PRs)
-10. Clean up release resources
+3. Poll Maven Central for artifact availability
+4. Deploy Docker images to IBM Cloud Container Registry
+5. Create version tags across all repositories
+6. Upload CLI and Isolated/MVP releases to GitHub
+7. Trigger Homebrew and Scoop update workflows (creates PRs)
+8. Bump development version (creates PRs)
+9. Clean up release resources
 
 
 **Manual actions required**:
-1. Approve Maven Central publication in Portal UI - see [31-publish-to-maven-central.md](./31-publish-to-maven-central.md)
-2. Review and merge PRs:
+1. Review and merge PRs:
    - [Homebrew tap PR](https://github.com/galasa-dev/homebrew-tap/pulls)
    - [Scoop bucket PR](https://github.com/galasa-dev/scoop-bucket/pulls)
    - [Galasa PR](https://github.com/galasa-dev/galasa/pulls)


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2627

## Changes
- [x] Set maven central publishing from `USER_MANAGED` to `AUTOMATIC` to automate the publishing of maven artifacts
- [x] Removed manual approval step from deployment workflow
- [x] Updated the conditions used to trigger release deployment workflow jobs since a failure caused subsequent jobs to run when they shouldn't have
- [x] Added missing `TERM` environment variable to release workflow so that it's consistent with pre-release workflow
- [x] Removed `ibmcloud` command from the deploy docker images job