### PR TITLE
Remove commands to publish to old icr registry

### DIFF
--- a/.github/workflows/release-deployment.yaml
+++ b/.github/workflows/release-deployment.yaml
@@ -157,16 +157,10 @@ jobs:
           docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
             icr.io/galasa/galasa-ui:${{ env.GALASA_VERSION }}
           docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
-            icr.io/galasadev/galasa-ui:${{ env.GALASA_VERSION }}
-          docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
             icr.io/galasa/galasa-ui:latest
-          docker tag ghcr.io/${{ env.NAMESPACE }}/webui:release \
-            icr.io/galasadev/galasa-ui:latest
 
           docker push icr.io/galasa/galasa-ui:${{ env.GALASA_VERSION }}
-          docker push icr.io/galasadev/galasa-ui:${{ env.GALASA_VERSION }}
           docker push icr.io/galasa/galasa-ui:latest
-          docker push icr.io/galasadev/galasa-ui:latest
 
       - name: Deploy Boot Embedded AMD64 image
         run: |
@@ -176,16 +170,10 @@ jobs:
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasa/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
-            icr.io/galasadev/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasa/galasa-boot-embedded-amd64:latest
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
-            icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
           docker push icr.io/galasa/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
-          docker push icr.io/galasadev/galasa-boot-embedded-amd64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasa/galasa-boot-embedded-amd64:latest
-          docker push icr.io/galasadev/galasa-boot-embedded-amd64:latest
 
       - name: Deploy Boot Embedded ARM64 image
         run: |
@@ -195,16 +183,10 @@ jobs:
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasa/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
-            icr.io/galasadev/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
             icr.io/galasa/galasa-boot-embedded-arm64:latest
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasa-boot-embedded:release \
-            icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
           docker push icr.io/galasa/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
-          docker push icr.io/galasadev/galasa-boot-embedded-arm64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasa/galasa-boot-embedded-arm64:latest
-          docker push icr.io/galasadev/galasa-boot-embedded-arm64:latest
 
       - name: Deploy CLI AMD64 image
         run: |
@@ -214,16 +196,10 @@ jobs:
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
             icr.io/galasa/galasa-cli-amd64:${{ env.GALASA_VERSION }}
           docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
-            icr.io/galasadev/galasa-cli-amd64:${{ env.GALASA_VERSION }}
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
             icr.io/galasa/galasa-cli-amd64:latest
-          docker tag ghcr.io/${{ env.NAMESPACE }}/galasactl-x86_64:release \
-            icr.io/galasadev/galasa-cli-amd64:latest
 
           docker push icr.io/galasa/galasa-cli-amd64:${{ env.GALASA_VERSION }}
-          docker push icr.io/galasadev/galasa-cli-amd64:${{ env.GALASA_VERSION }}
           docker push icr.io/galasa/galasa-cli-amd64:latest
-          docker push icr.io/galasadev/galasa-cli-amd64:latest
 
   create-version-tags:
     name: Create Version Tags


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2627

## Changes
- [x] Removed docker commands to push to the old icr.io/galasadev registry that is no longer used