### PR TITLE
Remove manual steps to update internal test CPS properties, and add GPG signing to automated version bumps

### DIFF
--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -5,11 +5,14 @@
 #
 # This workflow automates the "Bump to new version for development" process.
 #
-# REQUIRED SECRET:
+# REQUIRED SECRETS:
 # - GALASA_TEAM_GITHUB_TOKEN: A Personal Access Token (PAT) with permissions to:
 #   - Push to branches in galasa, helm, simplatform, webui, integratedtests, isolated, and automation repositories
 #   - Create pull requests in these repositories
 #   - Read and write packages (for Docker operations)
+# - GPG_KEY: Base64-encoded GPG private key (gpg --export-secret-keys | base64 -w0)
+# - GPG_KEYID: GPG key ID
+# - GPG_PASSPHRASE: Passphrase for the GPG key
 #
 # The token should have 'repo' and 'write:packages' scopes.
 #
@@ -74,10 +77,14 @@ jobs:
             exit 1
           fi
 
+  # bump-galasa is kept as a direct job because it requires a full toolchain
+  # (JDK, Gradle, Go, Python) and a build step that cannot run in the reusable workflow.
   bump-galasa:
     name: Bump Galasa version
     runs-on: ubuntu-latest
     needs: validate-inputs
+    outputs:
+      pr_url: ${{ steps.pr_url.outputs.pr_url }}
     steps:
       - name: Checkout Galasa repository
         uses: actions/checkout@v4
@@ -108,16 +115,28 @@ jobs:
         with:
           python-version: 3.x
 
+      - name: Import GPG key and configure git identity
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_KEY" | base64 --decode | gpg --batch --import
+          GPG_NAME=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/ (.*//' | sed 's/ <.*//' | head -1)
+          GPG_EMAIL=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/.*<//;s/>//' | head -1)
+          git config user.name "$GPG_NAME"
+          git config user.email "$GPG_EMAIL"
+          git config user.signingkey "$GPG_KEYID"
+          git config commit.gpgsign true
+          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
       - name: Delete existing branch if it exists
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git push origin --delete ${{ inputs.branch_name }} || true
           git branch -D ${{ inputs.branch_name }} || true
 
       - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
+        run: git checkout -b ${{ inputs.branch_name }}
 
       - name: Run set-version script
         run: |
@@ -136,9 +155,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
+          git commit -s -m "Bump version to ${{ inputs.new_version }}"
           git push origin ${{ inputs.branch_name }}
-          
           gh pr create \
             --title "Bump version to ${{ inputs.new_version }}" \
             --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
@@ -160,333 +178,117 @@ jobs:
           name: all-artifacts
           path: /home/runner/.m2/repository/dev/galasa
 
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
-
   bump-helm:
     name: Bump Helm version
-    runs-on: ubuntu-latest
     needs: validate-inputs
-    steps:
-      - name: Checkout Helm repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/helm
-          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-          ref: main
-
-      - name: Delete existing branch if it exists
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin --delete ${{ inputs.branch_name }} || true
-          git branch -D ${{ inputs.branch_name }} || true
-
-      - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
-
-      - name: Run set-version script
-        run: |
-          chmod +x set-version.sh
-          ./set-version.sh --version ${{ inputs.new_version }}
-
-      - name: Push changes and create PR
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
-          git push origin ${{ inputs.branch_name }}
-          
-          gh pr create \
-            --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
-            --base main \
-            --head ${{ inputs.branch_name }}
-
-      - name: Output PR URL
-        id: pr_url
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "Helm PR created: ${PR_URL}"
-
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    uses: ./.github/workflows/bump-repo-version.yaml
+    with:
+      repository: ${{ github.repository_owner }}/helm
+      new_version: ${{ inputs.new_version }}
+      released_version: ${{ inputs.released_version }}
+      branch_name: ${{ inputs.branch_name }}
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bump-simplatform:
     name: Bump Simplatform version
-    runs-on: ubuntu-latest
     needs: [validate-inputs, bump-galasa]
-    steps:
-      - name: Checkout Simplatform repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/simplatform
-          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-          ref: main
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'semeru'
-
-      - name: Delete existing branch if it exists
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin --delete ${{ inputs.branch_name }} || true
-          git branch -D ${{ inputs.branch_name }} || true
-
-      - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
-
-      # The simplatform set-version script runs a build that requires the built dev.galasa artifacts
-      # to be present in the local Maven repository. These artifacts were built and uploaded by the
-      # bump-galasa job, so we download them here before running set-version.
-      - name: Download All 'dev.galasa' Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: all-artifacts
-          path: /home/runner/.m2/repository/dev/galasa
-
-      - name: Run set-version script
-        run: |
-          chmod +x set-version.sh
-          ./set-version.sh --version ${{ inputs.new_version }}
-
-      - name: Push changes and create PR
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
-          git push origin ${{ inputs.branch_name }}
-          
-          gh pr create \
-            --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
-            --base main \
-            --head ${{ inputs.branch_name }}
-
-      - name: Output PR URL
-        id: pr_url
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "Simplatform PR created: ${PR_URL}"
-
-      - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: simplatform-artifacts
-          path: /home/runner/.m2/repository/dev/galasa
-
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    uses: ./.github/workflows/bump-repo-version.yaml
+    with:
+      repository: ${{ github.repository_owner }}/simplatform
+      new_version: ${{ inputs.new_version }}
+      released_version: ${{ inputs.released_version }}
+      branch_name: ${{ inputs.branch_name }}
+      download_artifacts: true
+      upload_artifacts: true
+      artifact_name: simplatform-artifacts
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bump-webui:
     name: Bump Web UI version
-    runs-on: ubuntu-latest
     needs: [validate-inputs, bump-galasa]
-    steps:
-      - name: Checkout Web UI repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/webui
-          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-          ref: main
-
-      - name: Delete existing branch if it exists
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin --delete ${{ inputs.branch_name }} || true
-          git branch -D ${{ inputs.branch_name }} || true
-
-      - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
-
-      - name: Run set-version script
-        run: |
-          chmod +x set-version.sh
-          ./set-version.sh --version ${{ inputs.new_version }}
-
-      - name: Push changes and create PR
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
-          git push origin ${{ inputs.branch_name }}
-          
-          gh pr create \
-            --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
-            --base main \
-            --head ${{ inputs.branch_name }}
-
-      - name: Output PR URL
-        id: pr_url
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "Web UI PR created: ${PR_URL}"
-
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    uses: ./.github/workflows/bump-repo-version.yaml
+    with:
+      repository: ${{ github.repository_owner }}/webui
+      new_version: ${{ inputs.new_version }}
+      released_version: ${{ inputs.released_version }}
+      branch_name: ${{ inputs.branch_name }}
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bump-integratedtests:
     name: Bump Integratedtests version
-    runs-on: ubuntu-latest
     needs: [validate-inputs, bump-galasa]
-    steps:
-      - name: Checkout Integratedtests repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/integratedtests
-          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-          ref: main
-
-      - name: Delete existing branch if it exists
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin --delete ${{ inputs.branch_name }} || true
-          git branch -D ${{ inputs.branch_name }} || true
-
-      - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
-
-      - name: Run set-version script
-        run: |
-          chmod +x set-version.sh
-          ./set-version.sh --version ${{ inputs.new_version }}
-
-      - name: Push changes and create PR
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
-          git push origin ${{ inputs.branch_name }}
-          
-          gh pr create \
-            --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
-            --base main \
-            --head ${{ inputs.branch_name }}
-
-      - name: Output PR URL
-        id: pr_url
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "Integratedtests PR created: ${PR_URL}"
-
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    uses: ./.github/workflows/bump-repo-version.yaml
+    with:
+      repository: ${{ github.repository_owner }}/integratedtests
+      new_version: ${{ inputs.new_version }}
+      released_version: ${{ inputs.released_version }}
+      branch_name: ${{ inputs.branch_name }}
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   bump-isolated:
     name: Bump Isolated version
-    runs-on: ubuntu-latest
     needs: [validate-inputs, bump-simplatform]
-    steps:
-      - name: Checkout Isolated repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository_owner }}/isolated
-          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-          ref: main
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'semeru'
-
-      - name: Delete existing branch if it exists
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git push origin --delete ${{ inputs.branch_name }} || true
-          git branch -D ${{ inputs.branch_name }} || true
-
-      - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
-
-      # The isolated set-version script runs a build that requires the built dev.galasa artifacts
-      # to be present in the local Maven repository. These artifacts were built and uploaded by the
-      # bump-galasa job, so we download them here before running set-version.
-      - name: Download All 'dev.galasa' Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: all-artifacts
-          path: /home/runner/.m2/repository/dev/galasa
-
-      - name: Run set-version script
-        run: |
-          chmod +x set-version.sh
-          ./set-version.sh --version ${{ inputs.new_version }}
-
-      - name: Push changes and create PR
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          git add .
-          git commit -m "Bump version to ${{ inputs.new_version }}"
-          git push origin ${{ inputs.branch_name }}
-          
-          gh pr create \
-            --title "Bump version to ${{ inputs.new_version }}" \
-            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
-            --base main \
-            --head ${{ inputs.branch_name }}
-
-      - name: Output PR URL
-        id: pr_url
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        run: |
-          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          echo "Isolated PR created: ${PR_URL}"
-
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    uses: ./.github/workflows/bump-repo-version.yaml
+    with:
+      repository: ${{ github.repository_owner }}/isolated
+      new_version: ${{ inputs.new_version }}
+      released_version: ${{ inputs.released_version }}
+      branch_name: ${{ inputs.branch_name }}
+      download_artifacts: true
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_KEYID: ${{ secrets.GPG_KEYID }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   update-automation-cps:
     name: Update automation CPS properties
     runs-on: ubuntu-latest
     needs: validate-inputs
+    outputs:
+      pr_url: ${{ steps.pr_url.outputs.pr_url }}
     steps:
       - name: Checkout automation repository
         uses: actions/checkout@v4
 
+      - name: Import GPG key and configure git identity
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_KEY" | base64 --decode | gpg --batch --import
+          GPG_NAME=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/ (.*//' | sed 's/ <.*//' | head -1)
+          GPG_EMAIL=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/.*<//;s/>//' | head -1)
+          git config user.name "$GPG_NAME"
+          git config user.email "$GPG_EMAIL"
+          git config user.signingkey "$GPG_KEYID"
+          git config commit.gpgsign true
+          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
       - name: Delete existing branch if it exists
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git push origin --delete ${{ inputs.branch_name }} || true
           git branch -D ${{ inputs.branch_name }} || true
 
       - name: Create version bump branch
-        run: |
-          git checkout -b ${{ inputs.branch_name }}
+        run: git checkout -b ${{ inputs.branch_name }}
 
       - name: Run set-version.sh script
         run: |
@@ -500,9 +302,8 @@ jobs:
         run: |
           git add infrastructure/cicsk8s/galasa-dev/cps-properties.yaml
           git add infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml
-          git commit -m "Bump CPS properties to version ${{ inputs.new_version }}"
+          git commit -s -m "Bump CPS properties to version ${{ inputs.new_version }}"
           git push origin ${{ inputs.branch_name }}
-          
           gh pr create \
             --title "Bump CPS properties to version ${{ inputs.new_version }}" \
             --body "Automated CPS properties update from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
@@ -518,41 +319,38 @@ jobs:
           echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
           echo "Automation CPS PR created: ${PR_URL}"
 
-    outputs:
-      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+  # retag-docker-images:
+  #   name: Retag Docker images
+  #   runs-on: ubuntu-latest
+  #   needs: validate-inputs
+  #   steps:
+  #     - name: Log in to GitHub Container Registry
+  #       uses: docker/login-action@v3
+  #       env:
+  #         WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+  #         WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+  #       with:
+  #         registry: ${{ env.REGISTRY }}
+  #         username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+  #         password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
-  retag-docker-images:
-    name: Retag Docker images
-    runs-on: ubuntu-latest
-    needs: validate-inputs
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        env:
-          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
-          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
-          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
+  #     - name: Retag galasactl-ibm-x86_64 image
+  #       run: |
+  #         echo "Pulling release image..."
+  #         docker pull ghcr.io/galasa-dev/galasactl-ibm-x86_64:release
 
-      - name: Retag galasactl-ibm-x86_64 image
-        run: |
-          echo "Pulling release image..."
-          docker pull ghcr.io/galasa-dev/galasactl-ibm-x86_64:release
-          
-          echo "Tagging as stable..."
-          docker image tag ghcr.io/galasa-dev/galasactl-ibm-x86_64:release ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
-          
-          echo "Pushing stable image..."
-          docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
-          
-          echo "Successfully retagged galasactl-ibm-x86_64:release to stable"
+  #         echo "Tagging as stable..."
+  #         docker image tag ghcr.io/galasa-dev/galasactl-ibm-x86_64:release ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
+
+  #         echo "Pushing stable image..."
+  #         docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
+
+  #         echo "Successfully retagged galasactl-ibm-x86_64:release to stable"
 
   create-summary:
     name: Create workflow summary
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - bump-galasa
       - bump-helm
       - bump-simplatform
@@ -560,23 +358,23 @@ jobs:
       - bump-integratedtests
       - bump-isolated
       - update-automation-cps
-      - retag-docker-images
+      # - retag-docker-images
     if: always()
     steps:
       - name: Create summary
         run: |
           cat >> $GITHUB_STEP_SUMMARY << 'EOF'
           ## Development Version Bump Complete
-          
+
           ### Version Information
           - **Released Version**: ${{ inputs.released_version }}
           - **New Development Version**: ${{ inputs.new_version }}
           - **Branch Name**: ${{ inputs.branch_name }}
-          
+
           ### Pull Requests Created
-          
+
           The following PRs have been created and need to be reviewed and merged:
-          
+
           1. **Galasa**: ${{ needs.bump-galasa.outputs.pr_url }}
           2. **Helm**: ${{ needs.bump-helm.outputs.pr_url }}
           3. **Simplatform**: ${{ needs.bump-simplatform.outputs.pr_url }}
@@ -584,24 +382,24 @@ jobs:
           4. **Web UI**: ${{ needs.bump-webui.outputs.pr_url }}
           5. **Integratedtests**: ${{ needs.bump-integratedtests.outputs.pr_url }}
           6. **Isolated**: ${{ needs.bump-isolated.outputs.pr_url }}
-          
+
           ### Automation Repository Updates
           7. **Automation CPS**: ${{ needs.update-automation-cps.outputs.pr_url }}
              - Updates CPS properties in `infrastructure/cicsk8s/galasa-dev/cps-properties.yaml`
              - Updates GalasaStream resources in `infrastructure/galasa-kube1/galasa-service1/galasa-service-main-resources.yaml`
-          
+
           ### Docker Images
           - ✅ Retagged `galasactl-ibm-x86_64:release` to `stable`
-          
+
           ### Manual Steps Required
-          
+
           ⚠️ The following steps still need to be completed manually:
-          
+
           1. **Review and merge all PRs** in the order listed above
              - Wait for each PR build to pass before merging
              - Wait for each Main build to complete after merging
              - When Isolated Main build is triggered after Galasa CLI module build, cancel it (you'll rebuild it later)
-                    
+
           ### Notes
           - CPS properties are automatically applied by ArgoCD when changes are pushed to the automation repository
           - The `galasactl-ibm-x86_64:stable` image is now using version ${{ inputs.released_version }} for regression testing

--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -601,26 +601,7 @@ jobs:
              - Wait for each PR build to pass before merging
              - Wait for each Main build to complete after merging
              - When Isolated Main build is triggered after Galasa CLI module build, cancel it (you'll rebuild it later)
-          
-          2. **Update internal test CPS properties** using galasactl:
-             ```bash
-             galasactl properties set \
-               --namespace framework \
-               --name test.stream.internal-inttests.location \
-               --value https://development.galasa.dev/main/maven-repo/internal-inttests/dev/galasa/dev.galasa.internal-inttests.obr/${{ inputs.new_version }}/dev.galasa.internal-inttests.obr-${{ inputs.new_version }}-testcatalog.json \
-               --bootstrap <bootstrap-url>
-             
-             galasactl properties set \
-               --namespace framework \
-               --name test.stream.internal-inttests.obr \
-               --value mvn:dev.galasa/dev.galasa.internal-inttests.obr/${{ inputs.new_version }}/obr \
-               --bootstrap <bootstrap-url>
-             ```
-          
-          3. **Verify CPS properties** were applied correctly in the cluster
-          
-          4. **Monitor ArgoCD** to ensure the changes are synced properly
-          
+                    
           ### Notes
           - CPS properties are automatically applied by ArgoCD when changes are pushed to the automation repository
           - The `galasactl-ibm-x86_64:stable` image is now using version ${{ inputs.released_version }} for regression testing

--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -319,33 +319,33 @@ jobs:
           echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
           echo "Automation CPS PR created: ${PR_URL}"
 
-  # retag-docker-images:
-  #   name: Retag Docker images
-  #   runs-on: ubuntu-latest
-  #   needs: validate-inputs
-  #   steps:
-  #     - name: Log in to GitHub Container Registry
-  #       uses: docker/login-action@v3
-  #       env:
-  #         WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
-  #         WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
-  #       with:
-  #         registry: ${{ env.REGISTRY }}
-  #         username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
-  #         password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
+  retag-docker-images:
+    name: Retag Docker images
+    runs-on: ubuntu-latest
+    needs: validate-inputs
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        env:
+          WRITE_GITHUB_PACKAGES_USERNAME: ${{ vars.WRITE_GITHUB_PACKAGES_USERNAME }}
+          WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ env.WRITE_GITHUB_PACKAGES_TOKEN }}
 
-  #     - name: Retag galasactl-ibm-x86_64 image
-  #       run: |
-  #         echo "Pulling release image..."
-  #         docker pull ghcr.io/galasa-dev/galasactl-ibm-x86_64:release
+      - name: Retag galasactl-ibm-x86_64 image
+        run: |
+          echo "Pulling release image..."
+          docker pull ghcr.io/galasa-dev/galasactl-ibm-x86_64:release
 
-  #         echo "Tagging as stable..."
-  #         docker image tag ghcr.io/galasa-dev/galasactl-ibm-x86_64:release ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
+          echo "Tagging as stable..."
+          docker image tag ghcr.io/galasa-dev/galasactl-ibm-x86_64:release ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
 
-  #         echo "Pushing stable image..."
-  #         docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
+          echo "Pushing stable image..."
+          docker image push ghcr.io/galasa-dev/galasactl-ibm-x86_64:stable
 
-  #         echo "Successfully retagged galasactl-ibm-x86_64:release to stable"
+          echo "Successfully retagged galasactl-ibm-x86_64:release to stable"
 
   create-summary:
     name: Create workflow summary

--- a/.github/workflows/bump-repo-version.yaml
+++ b/.github/workflows/bump-repo-version.yaml
@@ -1,0 +1,146 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Reusable workflow: checkout a repository, import GPG, run its set-version.sh,
+# commit (signed), push, and open a PR.
+#
+# Callers that need Maven artifacts downloaded before set-version.sh runs should
+# pass download_artifacts: true. Callers that produce artifacts to share with
+# later jobs should pass upload_artifacts: true.
+#
+
+name: Bump repository version
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: 'Repository to bump (e.g. galasa-dev/helm)'
+        required: true
+        type: string
+      new_version:
+        required: true
+        type: string
+      released_version:
+        required: true
+        type: string
+      branch_name:
+        required: true
+        type: string
+      set_version_script:
+        description: 'Path to set-version.sh relative to the repo root'
+        required: false
+        type: string
+        default: 'set-version.sh'
+      commit_message:
+        description: 'Commit message'
+        required: false
+        type: string
+        default: 'Bump version to'
+      download_artifacts:
+        description: 'Download dev.galasa Maven artifacts before running set-version.sh'
+        required: false
+        type: boolean
+        default: false
+      upload_artifacts:
+        description: 'Upload dev.galasa Maven artifacts after running set-version.sh'
+        required: false
+        type: boolean
+        default: false
+      artifact_name:
+        description: 'Name for the uploaded artifact (required when upload_artifacts is true)'
+        required: false
+        type: string
+        default: 'artifacts'
+    secrets:
+      GALASA_TEAM_GITHUB_TOKEN:
+        required: true
+      GPG_KEY:
+        required: true
+      GPG_KEYID:
+        required: true
+      GPG_PASSPHRASE:
+        required: true
+    outputs:
+      pr_url:
+        description: 'URL of the pull request that was created'
+        value: ${{ jobs.bump.outputs.pr_url }}
+
+jobs:
+  bump:
+    name: Bump ${{ inputs.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr_url: ${{ steps.pr_url.outputs.pr_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          token: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          ref: main
+
+      - name: Import GPG key and configure git identity
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_KEY" | base64 --decode | gpg --batch --import
+          GPG_NAME=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/ (.*//' | sed 's/ <.*//' | head -1)
+          GPG_EMAIL=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/.*<//;s/>//' | head -1)
+          git config user.name "$GPG_NAME"
+          git config user.email "$GPG_EMAIL"
+          git config user.signingkey "$GPG_KEYID"
+          git config commit.gpgsign true
+          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
+      - name: Delete existing branch if it exists
+        run: |
+          git push origin --delete ${{ inputs.branch_name }} || true
+          git branch -D ${{ inputs.branch_name }} || true
+
+      - name: Create version bump branch
+        run: git checkout -b ${{ inputs.branch_name }}
+
+      - name: Download dev.galasa Maven artifacts
+        if: inputs.download_artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: all-artifacts
+          path: /home/runner/.m2/repository/dev/galasa
+
+      - name: Run set-version script
+        run: |
+          chmod +x ./${{ inputs.set_version_script }}
+          ./${{ inputs.set_version_script }} --version ${{ inputs.new_version }}
+
+      - name: Push changes and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          git add .
+          git commit -s -m "${{ inputs.commit_message }} ${{ inputs.new_version }}"
+          git push origin ${{ inputs.branch_name }}
+          gh pr create \
+            --title "${{ inputs.commit_message }} ${{ inputs.new_version }}" \
+            --body "Automated version bump from ${{ inputs.released_version }} to ${{ inputs.new_version }}" \
+            --base main \
+            --head ${{ inputs.branch_name }}
+
+      - name: Output PR URL
+        id: pr_url
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr view ${{ inputs.branch_name }} --json url -q .url)
+          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
+
+      - name: Upload dev.galasa Maven artifacts
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: /home/runner/.m2/repository/dev/galasa


### PR DESCRIPTION
## Why?
Related to https://github.com/galasa-dev/projectmanagement/issues/2627

## Changes
- [x] Removed the manual steps instructing maintainers to set internal CPS properties using galasactl, verify the CPS properties, and monitor ArgoCD - this has been automated and is no longer needed
- [x] Updated the bump-development-version workflow to include a step to import a GPG key and use it to sign commits for version bump PRs. This change also includes a reusable workflow to bump development versions in a given repository to reduce code duplication in the original bump-development-version workflow
- [x] Added DCO signoff to `git commit` commands