### PR TITLE
Move steps from pre-release and release scripts into GH Actions workflow, remove MEND scan steps from release docs

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -64,7 +64,7 @@ jobs:
           chmod +x 92-delete-argocd-apps.sh
           ./92-delete-argocd-apps.sh
 
-      - name: Run pre-release script
+      - name: Create ArgoCD apps
         env:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
           ARGOCD_SERVER: argocd.galasa.dev
@@ -72,14 +72,62 @@ jobs:
           ARGOCD_OPTS: --grpc-web
         working-directory: ${{ github.workspace }}/releasePipeline
         run: |
-          # Verify ArgoCD authentication is configured
           if [[ -z "$ARGOCD_AUTH_TOKEN" ]]; then
             echo "ARGOCD_AUTH_TOKEN secret is not set"
             exit 1
           fi
-          
           chmod +x 01-run-pre-release.sh
-          ./01-run-pre-release.sh --prerelease
+          ./01-run-pre-release.sh --step create-argocd-apps
+
+      - name: Delete release branches
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step delete-branches
+
+      - name: Capture branch creation timestamp
+        id: branch-timestamp
+        run: echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branches
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step create-branches
+
+      - name: Update Helm charts
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step helm-charts --start-time "${{ steps.branch-timestamp.outputs.timestamp }}"
+
+      - name: Capture build start timestamp
+        id: build-timestamp
+        run: echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Build Galasa monorepo
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step build-mono-repo
+
+      - name: Wait for isolated build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step wait-isolated --start-time "${{ steps.build-timestamp.outputs.timestamp }}"
+
+      - name: Wait for web UI build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step wait-webui --start-time "${{ steps.build-timestamp.outputs.timestamp }}"
+
+      - name: Check artifacts are signed
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-pre-release.sh --step check-artifacts-signed
 
       - name: Test MVP zip
         working-directory: ${{ github.workspace }}/releasePipeline

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,11 @@ jobs:
           chmod +x 92-delete-argocd-apps.sh
           ./92-delete-argocd-apps.sh
 
-      - name: Run release script
+      - name: Capture release start timestamp
+        id: release-timestamp
+        run: echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Create ArgoCD apps
         env:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
           ARGOCD_SERVER: argocd.galasa.dev
@@ -73,15 +77,110 @@ jobs:
           ARGOCD_OPTS: --grpc-web
         working-directory: ${{ github.workspace }}/releasePipeline
         run: |
-          # Verify ArgoCD authentication is configured
           if [[ -z "$ARGOCD_AUTH_TOKEN" ]]; then
             echo "ARGOCD_AUTH_TOKEN secret is not set"
             exit 1
           fi
-          
           chmod +x 01-run-release.sh wait-for-workflow.sh
           chmod +x 23-run-isolated-tests.sh 24-run-simbank-ivts.sh 25-run-ivts.sh
-          ./01-run-release.sh
+          ./01-run-release.sh --step create-argocd-apps
+
+      - name: Delete release branches
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step delete-branches
+
+      - name: Capture branch creation timestamp
+        id: branch-timestamp
+        run: echo "timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branches
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step create-branches
+
+      - name: Update Helm charts
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step helm-charts --start-time "${{ steps.branch-timestamp.outputs.timestamp }}"
+
+      - name: Build Galasa monorepo
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step build-mono-repo
+
+      - name: Wait for Isolated build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step wait-isolated --start-time "${{ steps.release-timestamp.outputs.timestamp }}"
+
+      - name: Wait for Web UI build
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step wait-webui --start-time "${{ steps.release-timestamp.outputs.timestamp }}"
+
+      - name: Check artifacts are signed
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step check-artifacts-signed
+
+      - name: Test MVP zip
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step test-mvp-zip
+
+      - name: Start Isolated regression tests
+        id: isolated-tests
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          run_id=$(./01-run-release.sh --step run-isolated-tests)
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Start Simbank IVTs
+        id: simbank-ivts
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          run_id=$(./01-run-release.sh --step run-simbank-ivts)
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Start Core IVTs
+        id: core-ivts
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: |
+          run_id=$(./01-run-release.sh --step run-core-ivts)
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Isolated regression tests
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step wait-regression-isolated --run-id "${{ steps.isolated-tests.outputs.run-id }}"
+
+      - name: Wait for Simbank IVTs
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step wait-regression-simbank --run-id "${{ steps.simbank-ivts.outputs.run-id }}"
+
+      - name: Wait for Core IVTs
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        working-directory: ${{ github.workspace }}/releasePipeline
+        run: ./01-run-release.sh --step wait-regression-core --run-id "${{ steps.core-ivts.outputs.run-id }}"
 
       - name: Upload MVP test results on failure
         if: failure()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,56 +131,30 @@ jobs:
         working-directory: ${{ github.workspace }}/releasePipeline
         run: ./01-run-release.sh --step check-artifacts-signed
 
-      - name: Test MVP zip
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: ./01-run-release.sh --step test-mvp-zip
+      - parallel:
+        - name: Test MVP zip
+          env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          working-directory: ${{ github.workspace }}/releasePipeline
+          run: ./01-run-release.sh --step test-mvp-zip
 
-      - name: Start Isolated regression tests
-        id: isolated-tests
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: |
-          run_id=$(./01-run-release.sh --step run-isolated-tests)
-          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+        - name: Run Isolated regression tests
+          env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          working-directory: ${{ github.workspace }}/releasePipeline
+          run: ./01-run-release.sh --step run-isolated-tests
 
-      - name: Start Simbank IVTs
-        id: simbank-ivts
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: |
-          run_id=$(./01-run-release.sh --step run-simbank-ivts)
-          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+        - name: Run Simbank IVTs
+          env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          working-directory: ${{ github.workspace }}/releasePipeline
+          run: ./01-run-release.sh --step run-simbank-ivts
 
-      - name: Start Core IVTs
-        id: core-ivts
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: |
-          run_id=$(./01-run-release.sh --step run-core-ivts)
-          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for Isolated regression tests
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: ./01-run-release.sh --step wait-regression-isolated --run-id "${{ steps.isolated-tests.outputs.run-id }}"
-
-      - name: Wait for Simbank IVTs
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: ./01-run-release.sh --step wait-regression-simbank --run-id "${{ steps.simbank-ivts.outputs.run-id }}"
-
-      - name: Wait for Core IVTs
-        env:
-          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-        working-directory: ${{ github.workspace }}/releasePipeline
-        run: ./01-run-release.sh --step wait-regression-core --run-id "${{ steps.core-ivts.outputs.run-id }}"
+        - name: Run Core IVTs
+          env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+          working-directory: ${{ github.workspace }}/releasePipeline
+          run: ./01-run-release.sh --step run-core-ivts
 
       - name: Upload MVP test results on failure
         if: failure()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ibm/detect-secrets
-    rev: 0.13.1+ibm.62.dss
+    rev: 0.13.1+ibm.64.dss
     hooks:
       - id: detect-secrets # pragma: whitelist secret
         args: [--baseline, .secrets.baseline, --use-all-plugins, --fail-on-unaudited]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "build-images/github-webhook-receiver/go.sum|go.work.sum|offline-tools/copyrighter/go.sum|build-images/github-webhook-monitor/go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-06-06T16:00:05Z",
+  "generated_at": "2026-08-14T13:21:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -140,7 +140,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.62.dss",
+  "version": "0.13.1+ibm.64.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/releasePipeline/01-run-pre-release.sh
+++ b/releasePipeline/01-run-pre-release.sh
@@ -5,13 +5,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-#-----------------------------------------------------------------------------------------                   
+#-----------------------------------------------------------------------------------------
 #
-# Objectives: Run all the pre-release steps 
+# Objectives: Run pre-release steps. Runs all steps when invoked without --step, or a
+#             single named step when --step <name> is supplied.
 #
 # Environment variable over-rides:
-# 
-#-----------------------------------------------------------------------------------------     
+#
+#-----------------------------------------------------------------------------------------
 
 # Where is this script executing from ?
 RELEASE_BASEDIR=$(dirname "$0");pushd $RELEASE_BASEDIR 2>&1 >> /dev/null ;RELEASE_BASEDIR=$(pwd);popd 2>&1 >> /dev/null
@@ -48,43 +49,145 @@ warn()      { printf "${tan}➜ %s${reset}\n" "$@" ; }
 bold()      { printf "${bold}%s${reset}\n" "$@" ; }
 note()      { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
 
+#-----------------------------------------------------------------------------------------
+# Step functions
+#-----------------------------------------------------------------------------------------
+
+function step_create_argocd_apps {
+    h1 "run 02-create-argocd-apps.sh"
+    $RELEASE_BASEDIR/02-create-argocd-apps.sh --prerelease
+}
+
+function step_delete_branches {
+    h1 "run 03-repo-branches-delete.sh"
+    $RELEASE_BASEDIR/03-repo-branches-delete.sh --prerelease
+}
+
+function step_create_branches {
+    h1 "run 04-repo-branches-create.sh"
+    $RELEASE_BASEDIR/04-repo-branches-create.sh --prerelease
+}
+
+function step_helm_charts {
+    local start_time=$1
+    h1 "run 05-helm-charts.sh"
+    $RELEASE_BASEDIR/05-helm-charts.sh --prerelease --start-time "${start_time}"
+}
+
+function step_build_mono_repo {
+    h1 "run 10-build-galasa-mono-repo.sh"
+    $RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --prerelease --wait
+}
+
+function step_wait_isolated {
+    local start_time=$1
+    h1 "Waiting for isolated build to complete"
+    $RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/isolated" --workflow "build.yaml" --branch "prerelease" --start-time "${start_time}" --name "Isolated build" --sleep 120
+}
+
+function step_wait_webui {
+    local start_time=$1
+    h1 "Waiting for web UI build to complete"
+    $RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/webui" --workflow "build.yaml" --branch "prerelease" --start-time "${start_time}" --name "Web UI build"
+}
+
+function step_check_artifacts_signed {
+    h1 "run 20-check-artifacts-signed.sh"
+    $RELEASE_BASEDIR/20-check-artifacts-signed.sh --prerelease
+}
+
+#-----------------------------------------------------------------------------------------
+# Parse arguments
+#-----------------------------------------------------------------------------------------
+STEP=""
+START_TIME=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --step)
+            STEP="$2"
+            shift 2
+            ;;
+        --start-time)
+            START_TIME="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
 
 #-----------------------------------------------------------------------------------------
 # Main Program
 #-----------------------------------------------------------------------------------------
 set -e
 
-h1 "run 02-create-argocd-apps.sh"
-$RELEASE_BASEDIR/02-create-argocd-apps.sh --prerelease
+if [[ -z "${STEP}" ]]; then
+    h1 "Running all pre-release steps"
 
-h1 "run 03-repo-branches-delete.sh"
-$RELEASE_BASEDIR/03-repo-branches-delete.sh --prerelease
+    step_create_argocd_apps
+    step_delete_branches
 
-# Capture timestamp before creating branches
-# This ensures we can identify workflows triggered by the branch creation
-BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-info "Branch creation time: ${BRANCH_CREATE_TIME}"
+    BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    info "Branch creation time: ${BRANCH_CREATE_TIME}"
 
-h1 "run 04-repo-branches-create.sh"
-$RELEASE_BASEDIR/04-repo-branches-create.sh --prerelease
+    step_create_branches
+    step_helm_charts "${BRANCH_CREATE_TIME}"
 
-h1 "run 05-helm-charts.sh"
-$RELEASE_BASEDIR/05-helm-charts.sh --prerelease --start-time "${BRANCH_CREATE_TIME}"
+    BUILD_START_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    info "Build start time: ${BUILD_START_TIME}"
 
-h1 "run 10-build-galasa-mono-repo.sh"
+    step_build_mono_repo
+    step_wait_isolated "${BUILD_START_TIME}"
+    step_wait_webui "${BUILD_START_TIME}"
+    step_check_artifacts_signed
 
-# Capture the current time before starting the build
-# This ensures we only wait for workflows created after this point
-BUILD_START_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-info "Build start time: ${BUILD_START_TIME}"
+    success "Pre-release automation completed successfully!"
+    exit 0
+fi
 
-$RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --prerelease --wait
+case "${STEP}" in
+    create-argocd-apps)
+        step_create_argocd_apps
+        ;;
+    delete-branches)
+        step_delete_branches
+        ;;
+    create-branches)
+        step_create_branches
+        ;;
+    helm-charts)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: helm-charts"
+            exit 1
+        fi
+        step_helm_charts "${START_TIME}"
+        ;;
+    build-mono-repo)
+        step_build_mono_repo
+        ;;
+    wait-isolated)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: wait-isolated"
+            exit 1
+        fi
+        step_wait_isolated "${START_TIME}"
+        ;;
+    wait-webui)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: wait-webui"
+            exit 1
+        fi
+        step_wait_webui "${START_TIME}"
+        ;;
+    check-artifacts-signed)
+        step_check_artifacts_signed
+        ;;
+    *)
+        error "Unknown step: '${STEP}'"
+        exit 1
+        ;;
+esac
 
-h1 "Waiting for downstream builds to complete"
-$RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/isolated" --workflow "build.yaml" --branch "prerelease" --start-time "${BUILD_START_TIME}" --name "Isolated build" --sleep 120
-$RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/webui" --workflow "build.yaml" --branch "prerelease" --start-time "${BUILD_START_TIME}" --name "Web UI build"
-
-h1 "run 20-check-artifacts-signed.sh"
-$RELEASE_BASEDIR/20-check-artifacts-signed.sh --prerelease
-
-success "Pre-release automation completed successfully!"
+success "Step '${STEP}' completed successfully!"

--- a/releasePipeline/01-run-release.sh
+++ b/releasePipeline/01-run-release.sh
@@ -7,7 +7,8 @@
 #
 #-----------------------------------------------------------------------------------------
 #
-# Objectives: Run all the release steps
+# Objectives: Run release steps. Runs all steps when invoked without --step, or a
+#             single named step when --step <name> is supplied.
 #
 # Environment variable over-rides:
 #
@@ -54,31 +55,94 @@ bold()      { printf "${bold}%s${reset}\n" "$@" ; }
 note()      { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
 
 #-----------------------------------------------------------------------------------------
-# Functions
+# Step functions
 #-----------------------------------------------------------------------------------------
 
-function wait_for_workflow_completion {
+function step_create_argocd_apps {
+    h1 "Step 1: Set up ArgoCD apps and GitHub branches"
+    $RELEASE_BASEDIR/02-create-argocd-apps.sh --release
+}
+
+function step_delete_branches {
+    h1 "Step 2: Delete old release branches"
+    $RELEASE_BASEDIR/03-repo-branches-delete.sh --release
+}
+
+function step_create_branches {
+    h1 "Step 3: Create new release branches"
+    $RELEASE_BASEDIR/04-repo-branches-create.sh --release
+}
+
+function step_helm_charts {
+    local start_time=$1
+    h1 "Step 4: Check Helm charts released"
+    $RELEASE_BASEDIR/05-helm-charts.sh --release --start-time "${start_time}"
+}
+
+function step_build_mono_repo {
+    h1 "Step 5: Build Galasa monorepo"
+    $RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --release --wait
+}
+
+function step_wait_isolated {
+    local start_time=$1
+    h1 "Step 6: Wait for Isolated build"
+    $RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/isolated" --workflow "build.yaml" --branch "release" --start-time "${start_time}" --name "Isolated build" --sleep 120
+}
+
+function step_wait_webui {
+    local start_time=$1
+    h1 "Step 7: Wait for Web UI build"
+    $RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/webui" --workflow "build.yaml" --branch "release" --start-time "${start_time}" --name "Web UI build"
+}
+
+function step_check_artifacts_signed {
+    h1 "Step 8: Check artifacts are signed"
+    $RELEASE_BASEDIR/20-check-artifacts-signed.sh --release
+}
+
+function step_test_mvp_zip {
+    h1 "Step 9: Test MVP zip"
+    $RELEASE_BASEDIR/test-mvp-zip.sh --release
+}
+
+function step_run_isolated_tests {
+    h1 "Step 10a: Start Isolated tests workflow"
+    $RELEASE_BASEDIR/23-run-isolated-tests.sh --release 2>&1 | tail -n 1
+}
+
+function step_run_simbank_ivts {
+    h1 "Step 10b: Start Simbank IVTs workflow"
+    $RELEASE_BASEDIR/24-run-simbank-ivts.sh --release 2>&1 | tail -n 1
+}
+
+function step_run_core_ivts {
+    h1 "Step 10c: Start Core IVTs workflow"
+    $RELEASE_BASEDIR/25-run-ivts.sh --release 2>&1 | tail -n 1
+}
+
+function wait_for_regression_workflow {
     local repo=$1
     local run_id=$2
     local workflow_name=$3
-    
+
     MAX_WAIT_ITERATIONS=60
     COUNTER=0
     SLEEP_TIME_SECONDS=60
-    
+
     info "Waiting for ${workflow_name} to complete..."
-    
+
     while [[ $COUNTER -lt $MAX_WAIT_ITERATIONS ]]; do
         sleep $SLEEP_TIME_SECONDS || true
         ((COUNTER++)) || true
-        
+
         status=$(gh run view "$run_id" --repo "$repo" --json conclusion --jq '.conclusion' 2>/dev/null)
-        
+
         if [[ $? -ne 0 ]]; then
             warn "Failed to query workflow status"
             continue
         fi
-        
+
         if [[ "$status" == "success" ]]; then
             success "${workflow_name} completed successfully"
             return 0
@@ -86,103 +150,178 @@ function wait_for_workflow_completion {
             error "${workflow_name} failed. Check https://github.com/${repo}/actions/runs/${run_id}"
             exit 1
         fi
-        
+
         # Show progress every 5 minutes
         if [[ $((COUNTER % 5)) -eq 0 ]]; then
             info "${workflow_name} still running... (${COUNTER} minutes elapsed)"
         fi
     done
-    
+
     error "Timed out waiting for ${workflow_name}"
     exit 1
 }
 
-function run_github_regression_tests {
-    h2 "Starting GitHub Actions regression tests in parallel"
-    
-    # Start all three workflows in parallel using existing scripts
-    info "Starting Isolated tests workflow..."
-    isolated_run_id=$($RELEASE_BASEDIR/23-run-isolated-tests.sh --release 2>&1 | tail -n 1)
-    if [[ $? != 0 || -z "$isolated_run_id" ]]; then
-        error "Failed to start Isolated tests workflow"
-        exit 1
-    fi
-    
-    info "Starting Simbank IVTs workflow..."
-    simbank_run_id=$($RELEASE_BASEDIR/24-run-simbank-ivts.sh --release 2>&1 | tail -n 1)
-    if [[ $? != 0 || -z "$simbank_run_id" ]]; then
-        error "Failed to start Simbank IVTs workflow"
-        exit 1
-    fi
-    
-    info "Starting Core IVTs workflow..."
-    core_run_id=$($RELEASE_BASEDIR/25-run-ivts.sh --release 2>&1 | tail -n 1)
-    if [[ $? != 0 || -z "$core_run_id" ]]; then
-        error "Failed to start Core IVTs workflow"
-        exit 1
-    fi
-    
-    success "Workflow runs started:"
-    bold "  - Isolated tests: https://github.com/galasa-dev/isolated/actions/runs/${isolated_run_id}"
-    bold "  - Simbank IVTs: https://github.com/galasa-dev/simplatform/actions/runs/${simbank_run_id}"
-    bold "  - Core IVTs: https://github.com/galasa-dev/automation/actions/runs/${core_run_id}"
-    
-    # Wait for all workflows to complete
-    wait_for_workflow_completion "galasa-dev/isolated" "$isolated_run_id" "Isolated tests"
-    wait_for_workflow_completion "galasa-dev/simplatform" "$simbank_run_id" "Simbank IVTs"
-    wait_for_workflow_completion "galasa-dev/automation" "$core_run_id" "Core IVTs"
-    
-    success "All GitHub Actions regression tests completed successfully"
+function step_wait_regression_isolated {
+    local run_id=$1
+    h1 "Step 10d: Wait for Isolated regression tests"
+    wait_for_regression_workflow "galasa-dev/isolated" "${run_id}" "Isolated tests"
+}
+
+function step_wait_regression_simbank {
+    local run_id=$1
+    h1 "Step 10e: Wait for Simbank IVTs"
+    wait_for_regression_workflow "galasa-dev/simplatform" "${run_id}" "Simbank IVTs"
+}
+
+function step_wait_regression_core {
+    local run_id=$1
+    h1 "Step 10f: Wait for Core IVTs"
+    wait_for_regression_workflow "galasa-dev/automation" "${run_id}" "Core IVTs"
 }
 
 #-----------------------------------------------------------------------------------------
-# Main logic
+# Parse arguments
 #-----------------------------------------------------------------------------------------
+STEP=""
+START_TIME=""
+RUN_ID=""
 
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --step)
+            STEP="$2"
+            shift 2
+            ;;
+        --start-time)
+            START_TIME="$2"
+            shift 2
+            ;;
+        --run-id)
+            RUN_ID="$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+#-----------------------------------------------------------------------------------------
+# Main Program
+#-----------------------------------------------------------------------------------------
 set -e
 
-# Capture start time for workflow tracking
-START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-info "Release process started at: ${START_TIME}"
+if [[ -z "${STEP}" ]]; then
+    h1 "Running all release steps"
 
-h1 "Step 1: Set up ArgoCD apps and GitHub branches"
-$RELEASE_BASEDIR/02-create-argocd-apps.sh --release
+    START_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    info "Release process started at: ${START_TIME}"
 
-h1 "Step 2: Delete old release branches"
-$RELEASE_BASEDIR/03-repo-branches-delete.sh --release
+    step_create_argocd_apps
+    step_delete_branches
 
-# Capture timestamp before creating branches
-# This ensures we can identify workflows triggered by the branch creation
-BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-info "Branch creation time: ${BRANCH_CREATE_TIME}"
+    BRANCH_CREATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    info "Branch creation time: ${BRANCH_CREATE_TIME}"
 
-h1 "Step 3: Create new release branches"
-$RELEASE_BASEDIR/04-repo-branches-create.sh --release
+    step_create_branches
+    step_helm_charts "${BRANCH_CREATE_TIME}"
+    step_build_mono_repo
+    step_wait_isolated "${START_TIME}"
+    step_wait_webui "${START_TIME}"
+    step_check_artifacts_signed
+    step_test_mvp_zip
 
-h1 "Step 4: Check Helm charts released"
-$RELEASE_BASEDIR/05-helm-charts.sh --release --start-time "${BRANCH_CREATE_TIME}"
+    h1 "Step 10: Run GitHub Actions regression tests"
+    isolated_run_id=$(step_run_isolated_tests)
+    simbank_run_id=$(step_run_simbank_ivts)
+    core_run_id=$(step_run_core_ivts)
+    step_wait_regression_isolated "${isolated_run_id}"
+    step_wait_regression_simbank "${simbank_run_id}"
+    step_wait_regression_core "${core_run_id}"
 
-h1 "Step 5: Build Galasa mono repo"
-$RELEASE_BASEDIR/10-build-galasa-mono-repo.sh --release --wait
+    success "Automated release steps completed. Manual steps remain."
+    bold ""
+    bold "Next manual steps:"
+    bold "1. MEND scan (see release.md line 63)"
+    bold "2. Run Tekton regression tests (scripts 27-28)"
+    bold "3. Run the 'Deploy new Galasa version' workflow"
+    exit 0
+fi
 
-h1 "Step 6: Wait for Isolated build"
-$RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/isolated" --workflow "build.yaml" --branch "release" --start-time "$START_TIME" --name "Isolated build" --sleep 120
+case "${STEP}" in
+    create-argocd-apps)
+        step_create_argocd_apps
+        ;;
+    delete-branches)
+        step_delete_branches
+        ;;
+    create-branches)
+        step_create_branches
+        ;;
+    helm-charts)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: helm-charts"
+            exit 1
+        fi
+        step_helm_charts "${START_TIME}"
+        ;;
+    build-mono-repo)
+        step_build_mono_repo
+        ;;
+    wait-isolated)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: wait-isolated"
+            exit 1
+        fi
+        step_wait_isolated "${START_TIME}"
+        ;;
+    wait-webui)
+        if [[ -z "${START_TIME}" ]]; then
+            error "--start-time is required for step: wait-webui"
+            exit 1
+        fi
+        step_wait_webui "${START_TIME}"
+        ;;
+    check-artifacts-signed)
+        step_check_artifacts_signed
+        ;;
+    test-mvp-zip)
+        step_test_mvp_zip
+        ;;
+    run-isolated-tests)
+        step_run_isolated_tests
+        ;;
+    run-simbank-ivts)
+        step_run_simbank_ivts
+        ;;
+    run-core-ivts)
+        step_run_core_ivts
+        ;;
+    wait-regression-isolated)
+        if [[ -z "${RUN_ID}" ]]; then
+            error "--run-id is required for step: wait-regression-isolated"
+            exit 1
+        fi
+        step_wait_regression_isolated "${RUN_ID}"
+        ;;
+    wait-regression-simbank)
+        if [[ -z "${RUN_ID}" ]]; then
+            error "--run-id is required for step: wait-regression-simbank"
+            exit 1
+        fi
+        step_wait_regression_simbank "${RUN_ID}"
+        ;;
+    wait-regression-core)
+        if [[ -z "${RUN_ID}" ]]; then
+            error "--run-id is required for step: wait-regression-core"
+            exit 1
+        fi
+        step_wait_regression_core "${RUN_ID}"
+        ;;
+    *)
+        error "Unknown step: '${STEP}'"
+        exit 1
+        ;;
+esac
 
-h1 "Step 7: Wait for Web UI build"
-$RELEASE_BASEDIR/wait-for-workflow.sh --repo "galasa-dev/webui" --workflow "build.yaml" --branch "release" --start-time "$START_TIME" --name "Web UI build"
-
-h1 "Step 8: Check artifacts are signed"
-$RELEASE_BASEDIR/20-check-artifacts-signed.sh --release
-
-h1 "Step 9: Test MVP zip"
-$RELEASE_BASEDIR/test-mvp-zip.sh --release
-
-h1 "Step 10: Run GitHub Actions regression tests"
-run_github_regression_tests
-
-success "Automated release steps completed. Manual steps remain."
-bold ""
-bold "Next manual steps:"
-bold "1. MEND scan (see release.md line 63)"
-bold "2. Run Tekton regression tests (scripts 27-28)"
-bold "3. Run the 'Deploy new Galasa version' workflow"
+success "Step '${STEP}' completed successfully!"

--- a/releasePipeline/01-run-release.sh
+++ b/releasePipeline/01-run-release.sh
@@ -106,21 +106,6 @@ function step_test_mvp_zip {
     $RELEASE_BASEDIR/test-mvp-zip.sh --release
 }
 
-function step_run_isolated_tests {
-    h1 "Step 10a: Start Isolated tests workflow"
-    $RELEASE_BASEDIR/23-run-isolated-tests.sh --release 2>&1 | tail -n 1
-}
-
-function step_run_simbank_ivts {
-    h1 "Step 10b: Start Simbank IVTs workflow"
-    $RELEASE_BASEDIR/24-run-simbank-ivts.sh --release 2>&1 | tail -n 1
-}
-
-function step_run_core_ivts {
-    h1 "Step 10c: Start Core IVTs workflow"
-    $RELEASE_BASEDIR/25-run-ivts.sh --release 2>&1 | tail -n 1
-}
-
 function wait_for_regression_workflow {
     local repo=$1
     local run_id=$2
@@ -161,22 +146,33 @@ function wait_for_regression_workflow {
     exit 1
 }
 
-function step_wait_regression_isolated {
-    local run_id=$1
-    h1 "Step 10d: Wait for Isolated regression tests"
-    wait_for_regression_workflow "galasa-dev/isolated" "${run_id}" "Isolated tests"
+function launch_workflow_and_wait {
+    local script=$1
+    local repo=$2
+    local workflow_name=$3
+    local output
+    if ! output=$($script --release); then
+        error "Failed to start ${workflow_name}"
+        exit 1
+    fi
+    local run_id
+    run_id=$(echo "${output}" | tail -n 1)
+    wait_for_regression_workflow "${repo}" "${run_id}" "${workflow_name}"
 }
 
-function step_wait_regression_simbank {
-    local run_id=$1
-    h1 "Step 10e: Wait for Simbank IVTs"
-    wait_for_regression_workflow "galasa-dev/simplatform" "${run_id}" "Simbank IVTs"
+function step_run_isolated_tests {
+    h1 "Step 10a: Isolated tests"
+    launch_workflow_and_wait "$RELEASE_BASEDIR/23-run-isolated-tests.sh" "galasa-dev/isolated" "Isolated tests"
 }
 
-function step_wait_regression_core {
-    local run_id=$1
-    h1 "Step 10f: Wait for Core IVTs"
-    wait_for_regression_workflow "galasa-dev/automation" "${run_id}" "Core IVTs"
+function step_run_simbank_ivts {
+    h1 "Step 10b: Simbank IVTs"
+    launch_workflow_and_wait "$RELEASE_BASEDIR/24-run-simbank-ivts.sh" "galasa-dev/simplatform" "Simbank IVTs"
+}
+
+function step_run_core_ivts {
+    h1 "Step 10c: Core IVTs"
+    launch_workflow_and_wait "$RELEASE_BASEDIR/25-run-ivts.sh" "galasa-dev/automation" "Core IVTs"
 }
 
 #-----------------------------------------------------------------------------------------
@@ -184,7 +180,6 @@ function step_wait_regression_core {
 #-----------------------------------------------------------------------------------------
 STEP=""
 START_TIME=""
-RUN_ID=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -194,10 +189,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --start-time)
             START_TIME="$2"
-            shift 2
-            ;;
-        --run-id)
-            RUN_ID="$2"
             shift 2
             ;;
         *)
@@ -232,12 +223,9 @@ if [[ -z "${STEP}" ]]; then
     step_test_mvp_zip
 
     h1 "Step 10: Run GitHub Actions regression tests"
-    isolated_run_id=$(step_run_isolated_tests)
-    simbank_run_id=$(step_run_simbank_ivts)
-    core_run_id=$(step_run_core_ivts)
-    step_wait_regression_isolated "${isolated_run_id}"
-    step_wait_regression_simbank "${simbank_run_id}"
-    step_wait_regression_core "${core_run_id}"
+    step_run_isolated_tests
+    step_run_simbank_ivts
+    step_run_core_ivts
 
     success "Automated release steps completed. Manual steps remain."
     bold ""
@@ -296,27 +284,6 @@ case "${STEP}" in
         ;;
     run-core-ivts)
         step_run_core_ivts
-        ;;
-    wait-regression-isolated)
-        if [[ -z "${RUN_ID}" ]]; then
-            error "--run-id is required for step: wait-regression-isolated"
-            exit 1
-        fi
-        step_wait_regression_isolated "${RUN_ID}"
-        ;;
-    wait-regression-simbank)
-        if [[ -z "${RUN_ID}" ]]; then
-            error "--run-id is required for step: wait-regression-simbank"
-            exit 1
-        fi
-        step_wait_regression_simbank "${RUN_ID}"
-        ;;
-    wait-regression-core)
-        if [[ -z "${RUN_ID}" ]]; then
-            error "--run-id is required for step: wait-regression-core"
-            exit 1
-        fi
-        step_wait_regression_core "${RUN_ID}"
         ;;
     *)
         error "Unknown step: '${STEP}'"

--- a/releasePipeline/23-run-isolated-tests.sh
+++ b/releasePipeline/23-run-isolated-tests.sh
@@ -130,7 +130,5 @@ if [[ -z "$release_type" ]]; then
     ask_user_for_release_type
     run_isolated_tests
 else
-    # If called with a flag, suppress interactive output and return only run_id
-    run_id=$(run_isolated_tests 2>&1 | tail -n 1)
-    echo "${run_id}"
+    run_isolated_tests
 fi

--- a/releasePipeline/24-run-simbank-ivts.sh
+++ b/releasePipeline/24-run-simbank-ivts.sh
@@ -130,7 +130,5 @@ if [[ -z "$release_type" ]]; then
     ask_user_for_release_type
     run_simbank_ivts
 else
-    # If called with a flag, suppress interactive output and return only run_id
-    run_id=$(run_simbank_ivts 2>&1 | tail -n 1)
-    echo "${run_id}"
+    run_simbank_ivts
 fi

--- a/releasePipeline/25-run-ivts.sh
+++ b/releasePipeline/25-run-ivts.sh
@@ -130,7 +130,5 @@ if [[ -z "$release_type" ]]; then
     ask_user_for_release_type
     run_core_ivts
 else
-    # If called with a flag, suppress interactive output and return only run_id
-    run_id=$(run_core_ivts 2>&1 | tail -n 1)
-    echo "${run_id}"
+    run_core_ivts
 fi

--- a/releasePipeline/prerelease.md
+++ b/releasePipeline/prerelease.md
@@ -7,7 +7,6 @@ It may be beneficial to complete a pre-release before starting a vx.xx.x release
 ## Pre-release steps - Automated
 
 1. Run the [Pre-release GitHub Actions workflow](https://github.com/galasa-dev/automation/actions/workflows/pre-release.yaml). If the process fails at any stage, you can continue by re-running the script that failed from the manual steps and finish using the [manual steps below](#pre-release-steps---manual).
-2. When the Isolated pre-release build finishes, a Tekton pipeline to copy the MVP to an internal repo should start. Watch that pipeline and review the Mend scan results in the PR that gets opened. Then merge that PR.
 
 ## Pre-release steps - Manual
 
@@ -41,15 +40,9 @@ a new branch called `prerelease` in every github repo we need to build. **Note:*
 10. Run [20-check-artifacts-signed.sh](./20-check-artifacts-signed.sh). When prompted, choose the '`pre-release`' option.
     - This will search and check that one artifact from each Galasa module (platform, wrapping, gradle, maven, framework, extensions, managers and obr) contains a file called *.jar.asc which shows the artifacts have been signed. If the .asc files aren't present, debug and diagnose why the artifacts have not been signed.
 
-## Test and scan the MVP
+## Test the MVP
 
 Ensure you have completed either the [automated](#pre-release-steps---automated) or [manual](#pre-release-steps---manual) pre-release steps first.
-
-### MEND scan
-
-1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp) on how to do this. **Note:** the bundles `dev.galasa.wrapping.com.auth0.jwt` and `dev.galasa.wrapping.kafka.clients` are not included in the MVP, therefore if vulnerabilities are found only in these bundles, they will not affect any IBM scans. However, they should still be remediated before starting the proper release if possible.
-
-### Test the MVP
 
 Run the automated MVP testing script to verify the MVP zip works as described in the documentation:
 

--- a/releasePipeline/release.md
+++ b/releasePipeline/release.md
@@ -1,24 +1,5 @@
 # RELEASE PROCESS
 
-## Set up
-
-1. Clone the 'automation' repository, main branch. All the yaml and scripts you will be using can be found in the releasePipeline folder.
-2. Ensure the ArgoCD CLI is installed. The argocd cli can be downloaded [here]( https://argo-cd.readthedocs.io/en/stable/cli_installation/).
-3. Log into ArgoCD `argocd login --sso argocd.galasa.dev --grpc-web`
-4. Ensure GitHub CLI is istalled. It can be installed using the guide [here](https://github.com/cli/cli?tab=readme-ov-file#installation)
-5. Authenticate github cli using `gh auth login --web`
-6. You will need to log into both the internal cicsk8s and external ibmcloud Kubernetes clusters.
-7. Ensure you have the latest galasabld program. It can be downloaded [here](https://development.galasa.dev/main/binary/bld/). Add it on the path.
-8. jq needs to be installed. It can be downloaded [here](https://jqlang.github.io/jq/download/).
-9. watch needs to be installed.
-10. The ibmcloud CLI container registry service needs to be configured to the global region:
-
-``` shell
-ibmcloud cr region-set global
-```
-
-## Release steps
-
 **Option 1: Automated Release Process (Recommended)**
 
 The release process is split into two automated workflows:
@@ -40,17 +21,12 @@ This workflow will automatically:
 6. Test the MVP zip
 7. Run GitHub Actions regression tests in parallel (Isolated, Simbank IVTs, Core IVTs)
 8. Trigger the internal Tekton regression tests after the Isolated build finishes
-9. Trigger the Tekton pipeline to copy the MVP to an internal repo and open a PR for Mend scanning.
 
 Monitor the workflow run at: https://github.com/galasa-dev/automation/actions/workflows/release.yaml
 
 ### Part 2: Manual Steps
 
 After the automated workflow completes:
-
-#### MEND scan
-
-1. When the Isolated release build finishes, a Tekton pipeline to copy the MVP to an internal repo should start. Watch that pipeline and review the Mend scan results in the PR that gets opened. Then merge that PR.
 
 #### Tekton regression tests
 
@@ -106,6 +82,23 @@ This workflow will automatically:
 
 If you need to run steps individually or the automated workflows fail, follow these manual steps:
 
+### Set up
+
+1. Clone the 'automation' repository, main branch. All the yaml and scripts you will be using can be found in the releasePipeline folder.
+2. Ensure the ArgoCD CLI is installed. The argocd cli can be downloaded [here]( https://argo-cd.readthedocs.io/en/stable/cli_installation/).
+3. Log into ArgoCD `argocd login --sso argocd.galasa.dev --grpc-web`
+4. Ensure GitHub CLI is istalled. It can be installed using the guide [here](https://github.com/cli/cli?tab=readme-ov-file#installation)
+5. Authenticate github cli using `gh auth login --web`
+6. You will need to log into both the internal cicsk8s and external ibmcloud Kubernetes clusters.
+7. Ensure you have the latest galasabld program. It can be downloaded [here](https://development.galasa.dev/main/binary/bld/). Add it on the path.
+8. jq needs to be installed. It can be downloaded [here](https://jqlang.github.io/jq/download/).
+9. watch needs to be installed.
+10. The ibmcloud CLI container registry service needs to be configured to the global region:
+
+``` shell
+ibmcloud cr region-set global
+```
+
 ### Set up the ArgoCD apps and GitHub branches for the release
 
 1. Ensure you have completed the [set up](#set-up) before continuing.
@@ -132,10 +125,6 @@ If you need to run steps individually or the automated workflows fail, follow th
 ```bash
 ./test-mvp-zip.sh --release
 ```
-
-### MEND scan
-
-1. Follow instructions from the internal [developer-docs wiki](https://github.ibm.com/galasa/developer-docs/wiki/how-to-mend-scan-galasa-mvp).
 
 ### Run the regression tests
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2627

At the moment, the pre-release and release workflows run scripts that in turn run multiple steps. If the script being run fails, then maintainers only get the option to re-run the failed GH Actions job, which means running the entire script again.

This PR updates the workflows so that the steps are invoked in the workflows themselves. That way, if any of the steps fail, then maintainers get the option to re-run the workflow from the failures.

## Changes
- [x] Updated the 01-run-pre-release and 01-run-release scripts to accept a `--step` flag to invoke a specific step of the release process - if no `--step` is given, then the scripts will run like they did previously
- [x] Updated the pre-release and release GH Actions workflows to include explicit steps, where each step runs the appropriate release script and passes in a relevant `--step` argument
- [x] Fixed an issue where if an IVTs workflow failed, the corresponding script to run the workflow would always exit with code 0 rather than 1 since the final `echo` command runs without issue
- [x] Removed MEND scan instructions from the release and pre-release docs as this is automated
