### PR TITLE
Update GPG secrets named in bump-repo-version

### DIFF
--- a/.github/workflows/bump-repo-version.yaml
+++ b/.github/workflows/bump-repo-version.yaml
@@ -57,11 +57,11 @@ on:
     secrets:
       GALASA_TEAM_GITHUB_TOKEN:
         required: true
-      GPG_KEY:
+      GALASA_TEAM_GPG_KEY:
         required: true
-      GPG_KEYID:
+      GALASA_TEAM_GPG_KEYID:
         required: true
-      GPG_PASSPHRASE:
+      GALASA_TEAM_GPG_PASSPHRASE:
         required: true
     outputs:
       pr_url:


### PR DESCRIPTION
## Why?

Related to changes in https://github.com/galasa-dev/automation/pull/804

## Changes
- [x] Updated bump-repo-version workflow to use the correct `GALASA_TEAM*` GPG secrets