### PR TITLE
Update bump-repo-version to use the passed-in GPG secrets

### DIFF
--- a/.github/workflows/bump-repo-version.yaml
+++ b/.github/workflows/bump-repo-version.yaml
@@ -84,9 +84,9 @@ jobs:
 
       - name: Import GPG key and configure git identity
         env:
-          GPG_KEY: ${{ secrets.GALASA_TEAM_GPG_KEY }}
-          GPG_KEYID: ${{ secrets.GALASA_TEAM_GPG_KEYID }}
-          GPG_PASSPHRASE: ${{ secrets.GALASA_TEAM_GPG_PASSPHRASE }}
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_KEYID: ${{ secrets.GPG_KEYID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           echo "$GPG_KEY" | base64 --decode | gpg --batch --import
           GPG_NAME=$(gpg --list-keys --with-colons "$GPG_KEYID" | awk -F: '/^uid/{print $10}' | sed 's/ (.*//' | sed 's/ <.*//' | head -1)


### PR DESCRIPTION
## Why?

Related to https://github.com/galasa-dev/automation/pull/806

## Changes
- [x] The bump-repo-version workflow accepts `GPG_KEY`, `GPG_KEYID`, and `GPG_PASSPHRASE` secrets, which are passed in via bump-development-version - this PR updates the bump-repo-version to use those secrets in the workflow