### PR TITLE
Use GPG wrapper with passphrase passed in to skip pinentry dialog

### DIFF
--- a/.github/workflows/bump-development-version.yaml
+++ b/.github/workflows/bump-development-version.yaml
@@ -128,7 +128,17 @@ jobs:
           git config user.email "$GPG_EMAIL"
           git config user.signingkey "$GPG_KEYID"
           git config commit.gpgsign true
-          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
+          # Store the passphrase in a file and point git at a gpg wrapper that
+          # reads it, so git commit can sign without a pinentry dialog in CI.
+          echo "$GPG_PASSPHRASE" > ~/.gnupg/passphrase.txt
+          chmod 600 ~/.gnupg/passphrase.txt
+          cat > /usr/local/bin/gpg-passphrase-wrapper <<'WRAPPER'
+          #!/bin/sh
+          gpg --batch --yes --passphrase-file "$HOME/.gnupg/passphrase.txt" --pinentry-mode loopback "$@"
+          WRAPPER
+          chmod +x /usr/local/bin/gpg-passphrase-wrapper
+          git config gpg.program /usr/local/bin/gpg-passphrase-wrapper
 
       - name: Delete existing branch if it exists
         run: |
@@ -280,7 +290,17 @@ jobs:
           git config user.email "$GPG_EMAIL"
           git config user.signingkey "$GPG_KEYID"
           git config commit.gpgsign true
-          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
+          # Store the passphrase in a file and point git at a gpg wrapper that
+          # reads it, so git commit can sign without a pinentry dialog in CI.
+          echo "$GPG_PASSPHRASE" > ~/.gnupg/passphrase.txt
+          chmod 600 ~/.gnupg/passphrase.txt
+          cat > /usr/local/bin/gpg-passphrase-wrapper <<'WRAPPER'
+          #!/bin/sh
+          gpg --batch --yes --passphrase-file "$HOME/.gnupg/passphrase.txt" --pinentry-mode loopback "$@"
+          WRAPPER
+          chmod +x /usr/local/bin/gpg-passphrase-wrapper
+          git config gpg.program /usr/local/bin/gpg-passphrase-wrapper
 
       - name: Delete existing branch if it exists
         run: |
@@ -358,7 +378,7 @@ jobs:
       - bump-integratedtests
       - bump-isolated
       - update-automation-cps
-      # - retag-docker-images
+      - retag-docker-images
     if: always()
     steps:
       - name: Create summary

--- a/.github/workflows/bump-repo-version.yaml
+++ b/.github/workflows/bump-repo-version.yaml
@@ -95,7 +95,17 @@ jobs:
           git config user.email "$GPG_EMAIL"
           git config user.signingkey "$GPG_KEYID"
           git config commit.gpgsign true
-          echo "$GPG_PASSPHRASE" | gpg --batch --yes --passphrase-fd 0 --pinentry-mode loopback --output /dev/null --sign /dev/null
+
+          # Store the passphrase in a file and point git at a gpg wrapper that
+          # reads it, so git commit can sign without a pinentry dialog in CI.
+          echo "$GPG_PASSPHRASE" > ~/.gnupg/passphrase.txt
+          chmod 600 ~/.gnupg/passphrase.txt
+          cat > /usr/local/bin/gpg-passphrase-wrapper <<'WRAPPER'
+          #!/bin/sh
+          gpg --batch --yes --passphrase-file "$HOME/.gnupg/passphrase.txt" --pinentry-mode loopback "$@"
+          WRAPPER
+          chmod +x /usr/local/bin/gpg-passphrase-wrapper
+          git config gpg.program /usr/local/bin/gpg-passphrase-wrapper
 
       - name: Delete existing branch if it exists
         run: |


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2634

## Changes
- [x] Fixed an issue where the GPG pinentry dialog was being launched in the development version bump workflow, causing the workflow to fail - the workflow now uses a custom GPG wrapper with the correct GPG passphrase passed in so that the pinentry dialog is not needed